### PR TITLE
Astro 1549 button group bug

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -35,9 +35,9 @@ export namespace Components {
     }
     interface RuxButtonGroup {
         /**
-          * The alignment of buttons within the group
+          * The horizontal alignment of buttons within the group
          */
-        "align": 'left' | 'center' | 'right';
+        "hAlign": 'left' | 'center' | 'right';
     }
     interface RuxClassificationMarking {
         /**
@@ -18620,9 +18620,9 @@ declare namespace LocalJSX {
     }
     interface RuxButtonGroup {
         /**
-          * The alignment of buttons within the group
+          * The horizontal alignment of buttons within the group
          */
-        "align"?: 'left' | 'center' | 'right';
+        "hAlign"?: 'left' | 'center' | 'right';
     }
     interface RuxClassificationMarking {
         /**

--- a/src/components/rux-button-group/readme.md
+++ b/src/components/rux-button-group/readme.md
@@ -20,7 +20,7 @@ Common button groupings follow these conventions:
 By default button group aligns buttons to the left. Alternatively an `align` property may be passed to change alignment to `"center"` or `"right"`.
 
 ```xml
-<rux-button-group align="right">
+<rux-button-group h-align="right">
   <rux-button>Button 1</rux-button>
   <rux-button>Button 2</rux-button>
 </rux-button-group>
@@ -39,9 +39,9 @@ Read the [Rux-Buttons Readme](/?path=/info/components-buttons--standard-button) 
 
 ## Properties
 
-| Property | Attribute | Description                               | Type                            | Default  |
-| -------- | --------- | ----------------------------------------- | ------------------------------- | -------- |
-| `align`  | `align`   | The alignment of buttons within the group | `"center" \| "left" \| "right"` | `'left'` |
+| Property | Attribute | Description                                          | Type                            | Default  |
+| -------- | --------- | ---------------------------------------------------- | ------------------------------- | -------- |
+| `hAlign` | `h-align` | The horizontal alignment of buttons within the group | `"center" \| "left" \| "right"` | `'left'` |
 
 
 ## Dependencies

--- a/src/components/rux-button-group/readme.md
+++ b/src/components/rux-button-group/readme.md
@@ -26,14 +26,6 @@ By default button group aligns buttons to the left. Alternatively an `align` pro
 </rux-button-group>
 ```
 
-## Properties
-
-| Property | Attribute | Description | Type                           | Default |
-| -------- | --------- | ----------- | ------------------------------ | ------- |
-| `align`  | `align`   |             | `"N/A" \| "right" \| "center"` | `N/A`   |
-
-Read the [Rux-Buttons Readme](/?path=/info/components-buttons--standard-button) for more information.
-
 <!-- Auto Generated Below -->
 
 

--- a/src/components/rux-button-group/readme.md
+++ b/src/components/rux-button-group/readme.md
@@ -17,7 +17,7 @@ Common button groupings follow these conventions:
 </rux-button-group>
 ```
 
-By default button group aligns buttons to the left. Alternatively an `align` property may be passed to change alignment to `"center"` or `"right"`.
+By default button group aligns buttons to the left. Alternatively an `h-align` property may be passed to change alignment to `"center"` or `"right"`.
 
 ```xml
 <rux-button-group h-align="right">

--- a/src/components/rux-button-group/rux-button-group.tsx
+++ b/src/components/rux-button-group/rux-button-group.tsx
@@ -9,7 +9,10 @@ export class RuxButtonGroup {
     /**
      * The horizontal alignment of buttons within the group
      */
-    @Prop() hAlign: 'left' | 'center' | 'right' = 'left'
+    @Prop({
+        attribute: 'h-align',
+    })
+    hAlign: 'left' | 'center' | 'right' = 'left'
 
     render() {
         const { hAlign } = this

--- a/src/components/rux-button-group/rux-button-group.tsx
+++ b/src/components/rux-button-group/rux-button-group.tsx
@@ -7,19 +7,19 @@ import { Prop, Component, h } from '@stencil/core'
 })
 export class RuxButtonGroup {
     /**
-     * The alignment of buttons within the group
+     * The horizontal alignment of buttons within the group
      */
-    @Prop() align: 'left' | 'center' | 'right' = 'left'
+    @Prop() hAlign: 'left' | 'center' | 'right' = 'left'
 
     render() {
-        const { align } = this
+        const { hAlign } = this
         return (
             <div
                 class={{
                     'rux-button-group': true,
-                    'rux-button-group--left': align === 'left',
-                    'rux-button-group--right': align === 'right',
-                    'rux-button-group--center': align === 'center',
+                    'rux-button-group--left': hAlign === 'left',
+                    'rux-button-group--right': hAlign === 'right',
+                    'rux-button-group--center': hAlign === 'center',
                 }}
             >
                 <slot></slot>

--- a/src/components/rux-button-group/test/rux-button-group.spec.tsx
+++ b/src/components/rux-button-group/test/rux-button-group.spec.tsx
@@ -8,7 +8,7 @@ describe('rux-button-group', () => {
 
         expect(buttonGroup).toBeTruthy()
         expect(buttonGroup).toEqual({
-            align: 'left',
+            hAlign: 'left',
         })
     })
 
@@ -51,11 +51,11 @@ describe('rux-button-group', () => {
     it('aligns', async () => {
         const page = await newSpecPage({
             components: [RuxButtonGroup],
-            html: `<rux-button-group align="right"></rux-button-group>`,
+            html: `<rux-button-group h-align="right"></rux-button-group>`,
         })
 
         expect(page.root).toEqualHtml(`
-          <rux-button-group align="right">
+          <rux-button-group h-align="right">
             <mock:shadow-root>
               <div class="rux-button-group rux-button-group--right">
                 <slot></slot>

--- a/src/components/rux-modal/rux-modal.tsx
+++ b/src/components/rux-modal/rux-modal.tsx
@@ -120,7 +120,7 @@ export class RuxModal {
                     </header>
                     <div class="rux-modal__content">
                         <div class="rux-modal__message">{modalMessage}</div>
-                        <rux-button-group align="right">
+                        <rux-button-group h-align="right">
                             <rux-button
                                 secondary={confirmText.length > 0}
                                 onClick={_handleModalChoice.bind(this)}

--- a/src/stories-next/button-group.stories.mdx
+++ b/src/stories-next/button-group.stories.mdx
@@ -42,7 +42,7 @@ export const Default = (args) => {
         </style>
         <div style="padding: 10%; display: flex; justify-content: center;">
             <div class="example-container">
-                <rux-button-group .align="${args.align ? args.align : 'right'}">
+                <rux-button-group .h-align="${args.hAlign ? args.hAlign : 'right'}">
                     <rux-button outline>Cancel</rux-button>
                     <rux-button>Continue</rux-button>
                 </rux-button-group>
@@ -53,7 +53,7 @@ export const Default = (args) => {
 
 <Canvas>
     <Story
-      args={{align: 'right'}}
+      args={{hAlign: 'right'}}
       name="Button Group"
     >
       {Default.bind()}

--- a/src/stories/rux-button.stories.tsx
+++ b/src/stories/rux-button.stories.tsx
@@ -88,7 +88,7 @@ export const GroupedButtons = () => {
         Center: 'center',
     }
 
-    const align = select('Align', alignOptions, 'right')
+    const align = select('Align', alignOptions, '')
 
     return html`
         <style>
@@ -110,7 +110,7 @@ export const GroupedButtons = () => {
         </style>
         <div style="padding: 10%; display: flex; justify-content: center;">
             <div class="example-container">
-                <rux-button-group .align="${align}">
+                <rux-button-group h-align="${align}">
                     <rux-button secondary>Cancel</rux-button>
                     <rux-button>Continue</rux-button>
                 </rux-button-group>


### PR DESCRIPTION
## Brief Description

Update `align` property of button group component to h-align
align is a reserved word and some frameworks my throw an error (Angular did) 

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
