### PR TITLE
Astro 1553 tree keyboard controls

### DIFF
--- a/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/src/components/rux-tree-node/rux-tree-node.tsx
@@ -59,92 +59,28 @@ export class RuxTreeNode {
             return true
         }
 
-        if (ev.key === 'ArrowRight') {
-            ev.preventDefault()
-            this.expandNextNode()
+        switch (ev.key) {
+            case 'ArrowUp':
+                ev.preventDefault()
+                this._focusNext(-1)
+                break
+            case 'ArrowRight':
+                ev.preventDefault()
+                this._expandNextNode()
+                break
+            case 'ArrowDown':
+                ev.preventDefault()
+                this._focusNext(1)
+                break
+            case 'ArrowLeft':
+                ev.preventDefault()
+                this._collapseParent()
+                break
+            case 'Enter':
+                ev.preventDefault()
+                this.setSelected(true)
+                break
         }
-
-        if (ev.key === 'ArrowDown') {
-            ev.preventDefault()
-            this.focusNext(1)
-        }
-        if (ev.key === 'ArrowLeft') {
-            ev.preventDefault()
-            this.collapseParent()
-        }
-
-        if (ev.key === 'ArrowUp') {
-            ev.preventDefault()
-            this.focusNext(-1)
-        }
-
-        if (ev.key === 'Enter') {
-            ev.preventDefault()
-            this.setSelected(true)
-        }
-    }
-
-    expandNextNode() {
-        if (!this.expanded && this._hasChildren) {
-            this.setExpanded(true)
-        }
-    }
-
-    focusItem(el: HTMLElement) {
-        const parent = el?.shadowRoot?.querySelector(
-            '.parent'
-        ) as HTMLRuxTreeNodeElement
-        if (parent) {
-            parent.focus()
-        }
-    }
-
-    collapseParent() {
-        if (this.expanded) {
-            this.setExpanded(false)
-        } else if (this.el.parentElement) {
-            const parentTreeItemNode:
-                | Element
-                | null
-                | undefined = this.el.parentElement!.closest(
-                "[role='treeitem']"
-            )
-
-            if (parentTreeItemNode) {
-                this.focusItem(parentTreeItemNode as HTMLElement)
-            }
-        }
-    }
-    focusNext(direction: number) {
-        const visibleNodes = this._getVisibleNodes()
-        const currentIndex: number = visibleNodes.indexOf(this.el)
-        if (currentIndex !== -1) {
-            let nextElement: HTMLElement | undefined =
-                visibleNodes[currentIndex + direction]
-            if (nextElement !== undefined) {
-                while (nextElement.hasAttribute('disabled')) {
-                    const offset: number = direction >= 0 ? 1 : -1
-                    nextElement =
-                        visibleNodes[currentIndex + direction + offset]
-                    if (!nextElement) {
-                        break
-                    }
-                }
-            }
-
-            if (nextElement) {
-                this.focusItem(nextElement)
-            }
-        }
-    }
-
-    _getVisibleNodes() {
-        const rootTree = this.getTree() as HTMLRuxTreeElement
-
-        const nodes = Array.from(rootTree.querySelectorAll('rux-tree-node'))
-        return nodes.filter(
-            (node: HTMLRuxTreeNodeElement) => node.offsetParent !== null
-        )
     }
 
     connectedCallback() {
@@ -157,10 +93,6 @@ export class RuxTreeNode {
 
     get _hasChildren() {
         return this.children.length > 0
-    }
-
-    private getTree(): HTMLElement | null {
-        return this.el.closest("[role='tree']") as HTMLRuxTreeElement
     }
 
     /**
@@ -213,6 +145,68 @@ export class RuxTreeNode {
     _handleTreeNodeClick(e: MouseEvent) {
         e.stopPropagation()
         this.setSelected(!this.selected)
+    }
+
+    _expandNextNode() {
+        if (!this.expanded && this._hasChildren) {
+            this.setExpanded(true)
+        }
+    }
+
+    _focusItem(el: HTMLRuxTreeNodeElement) {
+        const parent = el?.shadowRoot?.querySelector('.parent') as HTMLElement
+        if (parent) {
+            parent.focus()
+        }
+    }
+
+    _collapseParent() {
+        if (this.expanded) {
+            this.setExpanded(false)
+        } else if (this.el.parentElement) {
+            const parentTreeItemNode:
+                | Element
+                | null
+                | undefined = this.el.parentElement!.closest(
+                "[role='treeitem']"
+            )
+
+            if (parentTreeItemNode) {
+                this._focusItem(parentTreeItemNode as HTMLRuxTreeNodeElement)
+            }
+        }
+    }
+
+    _focusNext(direction: number) {
+        const visibleNodes = this._getVisibleNodes()
+        const currentIndex: number = visibleNodes.indexOf(this.el)
+        if (currentIndex !== -1) {
+            let nextElement: HTMLRuxTreeNodeElement | undefined =
+                visibleNodes[currentIndex + direction]
+            if (nextElement !== undefined) {
+                // Skips any disabled nodes
+                while (nextElement.hasAttribute('disabled')) {
+                    const offset: number = direction >= 0 ? 1 : -1
+                    nextElement =
+                        visibleNodes[currentIndex + direction + offset]
+                    if (!nextElement) {
+                        break
+                    }
+                }
+            }
+
+            if (nextElement) {
+                this._focusItem(nextElement as HTMLRuxTreeNodeElement)
+            }
+        }
+    }
+
+    _getVisibleNodes() {
+        const rootTree = this.el.closest("[role='tree']") as HTMLRuxTreeElement
+        const nodes = Array.from(rootTree.querySelectorAll('rux-tree-node'))
+        return nodes.filter(
+            (node: HTMLRuxTreeNodeElement) => node.offsetParent !== null
+        )
     }
 
     render() {

--- a/src/components/rux-tree-node/rux-tree-node.tsx
+++ b/src/components/rux-tree-node/rux-tree-node.tsx
@@ -217,12 +217,12 @@ export class RuxTreeNode {
                 role="treeitem"
                 aria-expanded={this.expanded ? 'true' : 'false'}
                 aria-selected={this.selected ? 'true' : 'false'}
-                id={this.componentId}
                 onClick={(event: MouseEvent) =>
                     this._handleTreeNodeClick(event)
                 }
             >
                 <div
+                    id={this.componentId}
                     class={{
                         'tree-node': true,
                         'tree-node--expanded': this.expanded,

--- a/src/components/rux-tree-node/test/rux-tree-node.spec.tsx
+++ b/src/components/rux-tree-node/test/rux-tree-node.spec.tsx
@@ -8,9 +8,9 @@ describe('rux-tree-node', () => {
             html: `<rux-tree-node></rux-tree-node>`,
         })
         expect(page.root).toEqualHtml(`
-              <rux-tree-node aria-expanded="false" aria-selected="false" id="node-1" role="treeitem">
+              <rux-tree-node aria-expanded="false" aria-selected="false" role="treeitem">
                 <mock:shadow-root>
-                  <div class="tree-node">
+                  <div class="tree-node" id="node-1">
                     <div class="parent" tabindex="0">
                       <slot></slot>
                     </div>
@@ -35,11 +35,10 @@ describe('rux-tree-node', () => {
           <rux-tree-node
             aria-expanded="false"
             aria-selected="false"
-            id="node-2"
             role="treeitem"
           >
             <mock:shadow-root>
-              <div class="tree-node tree-node--has-children">
+              <div id="node-2" class="tree-node tree-node--has-children">
                 <div class="parent" tabindex="0">
                   <i class="arrow"></i>
                   <slot></slot>
@@ -53,12 +52,11 @@ describe('rux-tree-node', () => {
             <rux-tree-node
               aria-expanded="false"
               aria-selected="false"
-              id="node-3"
               role="treeitem"
               slot="node"
             >
               <mock:shadow-root>
-                <div class="tree-node">
+                <div id="node-3" class="tree-node">
                   <div class="parent" tabindex="0">
                     <slot></slot>
                   </div>

--- a/src/components/rux-tree/rux-tree.tsx
+++ b/src/components/rux-tree/rux-tree.tsx
@@ -50,9 +50,13 @@ export class RuxTree {
     handleNodeSelected(e: CustomEvent<string>) {
         const allNodes = document.querySelectorAll('rux-tree-node')
         if (allNodes) {
-            const previousSelectedNode = Array.from(allNodes).find(
-                (node) => node.selected && node.id !== e.detail
-            )
+            const previousSelectedNode = Array.from(allNodes).find((node) => {
+                return (
+                    node.selected &&
+                    node.shadowRoot?.querySelector('.tree-node')?.id !==
+                        e.detail
+                )
+            })
 
             if (previousSelectedNode) {
                 previousSelectedNode.selected = false

--- a/src/components/rux-tree/test/rux-tree.e2e.ts
+++ b/src/components/rux-tree/test/rux-tree.e2e.ts
@@ -1,11 +1,20 @@
-import { newE2EPage } from '@stencil/core/testing'
+import { E2EPage, newE2EPage } from '@stencil/core/testing'
 
 describe('rux-tree', () => {
-    it('renders', async () => {
-        const page = await newE2EPage()
-        await page.setContent('<rux-tree></rux-tree>')
+    let page!: E2EPage
 
-        const element = await page.find('rux-tree')
-        expect(element).toHaveClass('hydrated')
+    beforeEach(async () => {
+        page = await newE2EPage()
+        await page.setContent(`<rux-tree>
+        <rux-tree-node id="first">Level 1</rux-tree-node>
+        <rux-tree-node>Level 2</rux-tree-node>
+      </rux-tree>`)
+    })
+    it('focuses first node', async () => {
+        await page.keyboard.down('Tab')
+        const activeElement = await page.evaluate(
+            () => document.activeElement!.id
+        )
+        expect(activeElement).toBe('first')
     })
 })


### PR DESCRIPTION
## Brief Description

Add keyboard controls to Tree. 

- When a single-select tree receives focus:
  - If none of the nodes are selected before the tree receives focus, focus is set on the first node. 
- Right arrow:
  - When focus is on a closed node, opens the node; focus does not move. 
  - When focus is on an end node, does nothing. 
- Left arrow: 
  - When focus is on an open node, closes the node. 
  - When focus is on a child node that is also either an end node or a closed node, moves focus to its parent node. 
  - When focus is on a root node that is also either an end node or a closed node, does nothing. 
- Down Arrow: Moves focus to the next node that is focusable without opening or closing a node. 
  - Up Arrow: Moves focus to the previous node that is focusable without opening or closing a node. 
  - Enter: activates a node, i.e., performs its default action. For parent nodes, one possible default action is to open or close the node. In single-select trees where selection does not follow focus (see note below), the default action is typically to select the focused node.

## Related Issue

[ASTRO-1553](https://rocketcom.atlassian.net/browse/ASTRO-1553)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

A few of interactions [defined by w3c](https://w3c.github.io/aria-practices/#keyboard-interaction-23) have been omitted and added as backlog items due to their complexity vs. value.

## Types of changes
- [x] New feature

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
