### PR TITLE
Astro 1520 tab props

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "2021-07-09T18:39:25",
+    "timestamp": "2021-07-12T18:46:42",
     "compiler": {
         "name": "@stencil/core",
         "version": "2.5.2",
@@ -75051,6 +75051,26 @@
                     "docs": "Segmented button selected background color"
                 },
                 {
+                    "name": "--segmentedButtonSelectedBorderColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected border color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverBackgroundColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover background color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverBorderColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover border color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverTextColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover text color"
+                },
+                {
                     "name": "--segmentedButtonSelectedTextColor",
                     "annotation": "prop",
                     "docs": "Segmented button selected text color"
@@ -75213,14 +75233,9 @@
             "listeners": [],
             "styles": [
                 {
-                    "name": "--switchDisabledOffColor",
+                    "name": "--switchBackgroundColor",
                     "annotation": "prop",
-                    "docs": "the Switch disabled off color"
-                },
-                {
-                    "name": "--switchDisabledOnColor",
-                    "annotation": "prop",
-                    "docs": "the Switch disabled on color"
+                    "docs": "the Switch off color"
                 },
                 {
                     "name": "--switchHoverOffColor",
@@ -75233,14 +75248,9 @@
                     "docs": "the Switch hover on color"
                 },
                 {
-                    "name": "--switchOffColor",
+                    "name": "--switchOffBorderColor",
                     "annotation": "prop",
-                    "docs": "the Switch off color"
-                },
-                {
-                    "name": "--switchOnColor",
-                    "annotation": "prop",
-                    "docs": "the Switch on color"
+                    "docs": "the Switch off border color"
                 }
             ],
             "slots": [],
@@ -75645,35 +75655,22 @@
             "usage": {},
             "props": [
                 {
-                    "name": "_panels",
-                    "type": "HTMLRuxTabPanelElement[]",
-                    "mutable": true,
+                    "name": "small",
+                    "type": "boolean | undefined",
+                    "mutable": false,
+                    "attr": "small",
                     "reflectToAttr": false,
-                    "docs": "Holds all `<rux-tab-panel>` components based on the event emitted from the `<rux-tab-panels>` component.",
+                    "docs": "If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.",
                     "docsTags": [],
-                    "default": "[]",
                     "values": [
                         {
-                            "type": "HTMLRuxTabPanelElement[]"
-                        }
-                    ],
-                    "optional": false,
-                    "required": false
-                },
-                {
-                    "name": "_tabs",
-                    "type": "HTMLRuxTabElement[]",
-                    "mutable": true,
-                    "reflectToAttr": false,
-                    "docs": "Holds all `<rux-tab>` components that are children of `<rux-tabs>`.",
-                    "docsTags": [],
-                    "default": "[]",
-                    "values": [
+                            "type": "boolean"
+                        },
                         {
-                            "type": "HTMLRuxTabElement[]"
+                            "type": "undefined"
                         }
                     ],
-                    "optional": false,
+                    "optional": true,
                     "required": false
                 }
             ],
@@ -75681,7 +75678,7 @@
             "events": [],
             "listeners": [
                 {
-                    "event": "registerPanels",
+                    "event": "rux-register-panels",
                     "target": "window",
                     "capture": false,
                     "passive": false

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10958,13 +10958,9 @@ export namespace Components {
     }
     interface RuxTabs {
         /**
-          * Holds all `<rux-tab-panel>` components based on the event emitted from the `<rux-tab-panels>` component.
+          * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
          */
-        "_panels": Array<HTMLRuxTabPanelElement>;
-        /**
-          * Holds all `<rux-tab>` components that are children of `<rux-tabs>`.
-         */
-        "_tabs": Array<HTMLRuxTabElement>;
+        "small"?: boolean;
     }
     interface RuxTree {
     }
@@ -29563,13 +29559,9 @@ declare namespace LocalJSX {
     }
     interface RuxTabs {
         /**
-          * Holds all `<rux-tab-panel>` components based on the event emitted from the `<rux-tab-panels>` component.
+          * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
          */
-        "_panels"?: Array<HTMLRuxTabPanelElement>;
-        /**
-          * Holds all `<rux-tab>` components that are children of `<rux-tabs>`.
-         */
-        "_tabs"?: Array<HTMLRuxTabElement>;
+        "small"?: boolean;
     }
     interface RuxTree {
     }

--- a/src/components/rux-tabs/readme.md
+++ b/src/components/rux-tabs/readme.md
@@ -103,10 +103,9 @@ Astro UXDS Tab (child) properties are passed as simple attributes on the individ
 
 ## Properties
 
-| Property  | Attribute | Description                                                                                              | Type                       | Default |
-| --------- | --------- | -------------------------------------------------------------------------------------------------------- | -------------------------- | ------- |
-| `_panels` | --        | Holds all `<rux-tab-panel>` components based on the event emitted from the `<rux-tab-panels>` component. | `HTMLRuxTabPanelElement[]` | `[]`    |
-| `_tabs`   | --        | Holds all `<rux-tab>` components that are children of `<rux-tabs>`.                                      | `HTMLRuxTabElement[]`      | `[]`    |
+| Property | Attribute | Description                                                                                      | Type                   | Default     |
+| -------- | --------- | ------------------------------------------------------------------------------------------------ | ---------------------- | ----------- |
+| `small`  | `small`   | If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses. | `boolean \| undefined` | `undefined` |
 
 
 ## CSS Custom Properties

--- a/src/components/rux-tabs/rux-tabs.tsx
+++ b/src/components/rux-tabs/rux-tabs.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element, Listen } from '@stencil/core'
+import { Component, Host, h, State, Prop, Element, Listen } from '@stencil/core'
 
 @Component({
     tag: 'rux-tabs',
@@ -6,16 +6,20 @@ import { Component, Host, h, Prop, Element, Listen } from '@stencil/core'
     shadow: true,
 })
 export class RuxTabs {
+    @Element() el!: HTMLElement
     /**
      *  Holds all `<rux-tab-panel>` components based on the event emitted from the `<rux-tab-panels>` component.
      */
-    @Prop({ mutable: true }) _panels: Array<HTMLRuxTabPanelElement> = []
+    @State() _panels: Array<HTMLRuxTabPanelElement> = []
     /**
      *  Holds all `<rux-tab>` components that are children of `<rux-tabs>`.
      */
-    @Prop({ mutable: true }) _tabs: Array<HTMLRuxTabElement> = []
+    @State() _tabs: Array<HTMLRuxTabElement> = []
 
-    @Element() el!: HTMLElement
+    /**
+     * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
+     */
+    @Prop() small?: boolean
 
     @Listen('rux-register-panels', { target: 'window' })
     handleListen(e: CustomEvent) {

--- a/src/components/rux-tabs/rux-tabs.tsx
+++ b/src/components/rux-tabs/rux-tabs.tsx
@@ -17,7 +17,7 @@ export class RuxTabs {
 
     @Element() el!: HTMLElement
 
-    @Listen('registerPanels', { target: 'window' })
+    @Listen('rux-register-panels', { target: 'window' })
     handleListen(e: CustomEvent) {
         this._registerPanels(e)
     }

--- a/src/stories-next/tabs.stories.mdx
+++ b/src/stories-next/tabs.stories.mdx
@@ -117,13 +117,13 @@ export const Default = (args) => {
 
 The small property may be passed as a simple attribute on the Astro UXDS Tabs container element:
 
-export const Small = () => {
+export const Small = (args) => {
 return html`
     <div style="display: flex; flex-flow: column;">
         <div
             style="border: rgba(255,255,255, .25) dashed 1px; margin: 1vw 1vw 0; padding: 2px;"
         >
-            <rux-tabs small id="tab-set-id-2">
+            <rux-tabs ?small="${args.small}" id="tab-set-id-2">
                 <rux-tab id="tab-id-2-1">Tab 1</rux-tab>
                 <rux-tab id="tab-id-2-2">Tab 2</rux-tab>
                 <rux-tab id="tab-id-2-3" disabled>Tab 3 (disabled) </rux-tab>
@@ -151,7 +151,12 @@ return html`
 }
 
 <Canvas>
-    <Story name="Small">
+    <Story
+      name="Small"
+      args={{
+        small: true
+      }}
+    >
       {Small.bind()}
     </Story>
 </Canvas>


### PR DESCRIPTION
## Brief Description

* **BUG FIX!** fixes breaking change from [PR #61 ](https://github.com/RocketCommunicationsInc/astro-components-stencil/pull/61) where the event listener was not updated.
* Removes _panels and _tabs props in favor of `@State()`
* Documents `small` property

## JIRA Link

[ASTRO-1520](https://rocketcom.atlassian.net/browse/ASTRO-1520)

## Motivation and Context

* _panels and _tabs aren't props and were being used for internal state management. 
* `small` was not documented anywhere because no explicit prop was set.

## Types of changes

-   [x] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
