### PR TITLE
Astro 1568 km pop up update

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "2021-07-14T23:05:55",
+    "timestamp": "2021-07-14T23:20:03",
     "compiler": {
         "name": "@stencil/core",
         "version": "2.5.2",
@@ -74808,32 +74808,22 @@
                     "docs": "Size of Caret"
                 },
                 {
-                    "name": "--menuBackgroundColor",
+                    "name": "--popupCaretBackgroundColor",
+                    "annotation": "prop",
+                    "docs": "Pop Up Menu Caret Background Color"
+                },
+                {
+                    "name": "--popupMenuBackgroundColor",
                     "annotation": "prop",
                     "docs": "Pop Up Menu Backround Color"
                 },
                 {
-                    "name": "--menuBorderColor",
+                    "name": "--popupMenuBorderColor",
                     "annotation": "prop",
                     "docs": "Pop Up Menu Border Color"
                 },
                 {
-                    "name": "--menuItemBackgroundColor",
-                    "annotation": "prop",
-                    "docs": "Pop Up Menu Item Background Color"
-                },
-                {
-                    "name": "--menuItemHoverBackgroundColor",
-                    "annotation": "prop",
-                    "docs": "Pop Up Menu Item Hover Background Color"
-                },
-                {
-                    "name": "--menuItemHoverTextColor",
-                    "annotation": "prop",
-                    "docs": "Pop Up Menu Item Hover Text Color"
-                },
-                {
-                    "name": "--menuTextColor",
+                    "name": "--popupMenuTextColor",
                     "annotation": "prop",
                     "docs": "Pop Up Menu Text Color"
                 },

--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "2021-07-09T18:39:25",
+    "timestamp": "2021-07-14T23:05:55",
     "compiler": {
         "name": "@stencil/core",
         "version": "2.5.2",
@@ -207,18 +207,18 @@
             "filePath": "./src/components/rux-button-group/rux-button-group.tsx",
             "encapsulation": "shadow",
             "tag": "rux-button-group",
-            "readme": "# Grouped Buttons\n\nCommon button groupings follow these conventions:\n\n-   Cancel buttons are always presented to the left of actions such as “Submit.”\n\n-   Buttons within the same group should maintain their inherent size. Do not stretch one button to match another’s width.\n\n## Web Component Usage\n\n### 1. Render the Astro Button Group Web Component\n\n```xml\n<rux-button-group>\n  <rux-button>Button 1</rux-button>\n  <rux-button>Button 2</rux-button>\n</rux-button-group>\n```\n\nBy default button group aligns buttons to the left. Alternatively an `align` property may be passed to change alignment to `\"center\"` or `\"right\"`.\n\n```xml\n<rux-button-group align=\"right\">\n  <rux-button>Button 1</rux-button>\n  <rux-button>Button 2</rux-button>\n</rux-button-group>\n```\n\n## Properties\n\n| Property | Attribute | Description | Type                           | Default |\n| -------- | --------- | ----------- | ------------------------------ | ------- |\n| `align`  | `align`   |             | `\"N/A\" \\| \"right\" \\| \"center\"` | `N/A`   |\n\nRead the [Rux-Buttons Readme](/?path=/info/components-buttons--standard-button) for more information.\n",
+            "readme": "# Grouped Buttons\n\nCommon button groupings follow these conventions:\n\n-   Cancel buttons are always presented to the left of actions such as “Submit.”\n\n-   Buttons within the same group should maintain their inherent size. Do not stretch one button to match another’s width.\n\n## Web Component Usage\n\n### 1. Render the Astro Button Group Web Component\n\n```xml\n<rux-button-group>\n  <rux-button>Button 1</rux-button>\n  <rux-button>Button 2</rux-button>\n</rux-button-group>\n```\n\nBy default button group aligns buttons to the left. Alternatively an `h-align` property may be passed to change alignment to `\"center\"` or `\"right\"`.\n\n```xml\n<rux-button-group h-align=\"right\">\n  <rux-button>Button 1</rux-button>\n  <rux-button>Button 2</rux-button>\n</rux-button-group>\n```\n",
             "docs": "Common button groupings follow these conventions:\n\n-   Cancel buttons are always presented to the left of actions such as “Submit.”\n\n-   Buttons within the same group should maintain their inherent size. Do not stretch one button to match another’s width.",
             "docsTags": [],
             "usage": {},
             "props": [
                 {
-                    "name": "align",
+                    "name": "hAlign",
                     "type": "\"center\" | \"left\" | \"right\"",
                     "mutable": false,
-                    "attr": "align",
+                    "attr": "h-align",
                     "reflectToAttr": false,
-                    "docs": "The alignment of buttons within the group",
+                    "docs": "The horizontal alignment of buttons within the group",
                     "docsTags": [],
                     "default": "'left'",
                     "values": [
@@ -75051,6 +75051,26 @@
                     "docs": "Segmented button selected background color"
                 },
                 {
+                    "name": "--segmentedButtonSelectedBorderColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected border color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverBackgroundColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover background color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverBorderColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover border color"
+                },
+                {
+                    "name": "--segmentedButtonSelectedHoverTextColor",
+                    "annotation": "prop",
+                    "docs": "Segmented button selected hover text color"
+                },
+                {
                     "name": "--segmentedButtonSelectedTextColor",
                     "annotation": "prop",
                     "docs": "Segmented button selected text color"
@@ -75213,14 +75233,9 @@
             "listeners": [],
             "styles": [
                 {
-                    "name": "--switchDisabledOffColor",
+                    "name": "--switchBackgroundColor",
                     "annotation": "prop",
-                    "docs": "the Switch disabled off color"
-                },
-                {
-                    "name": "--switchDisabledOnColor",
-                    "annotation": "prop",
-                    "docs": "the Switch disabled on color"
+                    "docs": "the Switch off color"
                 },
                 {
                     "name": "--switchHoverOffColor",
@@ -75233,14 +75248,9 @@
                     "docs": "the Switch hover on color"
                 },
                 {
-                    "name": "--switchOffColor",
+                    "name": "--switchOffBorderColor",
                     "annotation": "prop",
-                    "docs": "the Switch off color"
-                },
-                {
-                    "name": "--switchOnColor",
-                    "annotation": "prop",
-                    "docs": "the Switch on color"
+                    "docs": "the Switch off border color"
                 }
             ],
             "slots": [],

--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "2021-07-14T23:20:03",
+    "timestamp": "2021-07-14T23:30:20",
     "compiler": {
         "name": "@stencil/core",
         "version": "2.5.2",

--- a/src/components/rux-menu-item-divider/rux-menu-item-divider.scss
+++ b/src/components/rux-menu-item-divider/rux-menu-item-divider.scss
@@ -2,7 +2,7 @@
     /**
       * @prop --menuItemDividerBorderColor: Menu Item Divider Border Color
     */
-    --menuItemDividerBorderColor: var(--primaryElementText);
+    --menuItemDividerBorderColor: var(--primary);
 
     display: block;
 

--- a/src/components/rux-pop-up-menu/readme.md
+++ b/src/components/rux-pop-up-menu/readme.md
@@ -164,17 +164,15 @@ Type: `Promise<boolean>`
 
 ## CSS Custom Properties
 
-| Name                             | Description                             |
-| -------------------------------- | --------------------------------------- |
-| `--caretLeft`                    | Position of Caret                       |
-| `--caretSize`                    | Size of Caret                           |
-| `--menuBackgroundColor`          | Pop Up Menu Backround Color             |
-| `--menuBorderColor`              | Pop Up Menu Border Color                |
-| `--menuItemBackgroundColor`      | Pop Up Menu Item Background Color       |
-| `--menuItemHoverBackgroundColor` | Pop Up Menu Item Hover Background Color |
-| `--menuItemHoverTextColor`       | Pop Up Menu Item Hover Text Color       |
-| `--menuTextColor`                | Pop Up Menu Text Color                  |
-| `--transitionSpeed`              | Transition Time of Pop Up Animation     |
+| Name                          | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `--caretLeft`                 | Position of Caret                   |
+| `--caretSize`                 | Size of Caret                       |
+| `--popupCaretBackgroundColor` | Pop Up Menu Caret Background Color  |
+| `--popupMenuBackgroundColor`  | Pop Up Menu Backround Color         |
+| `--popupMenuBorderColor`      | Pop Up Menu Border Color            |
+| `--popupMenuTextColor`        | Pop Up Menu Text Color              |
+| `--transitionSpeed`           | Transition Time of Pop Up Animation |
 
 
 ----------------------------------------------

--- a/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
+++ b/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
@@ -2,39 +2,20 @@
     display: block;
 
     /**
-      * @prop --menuBackgroundColor: Pop Up Menu Backround Color
+      * @prop --popupMenuBackgroundColor: Pop Up Menu Backround Color
     */
-    --menuBackgroundColor: var(--inputBackground);
 
     /**
-      * @prop --menuBorderColor: Pop Up Menu Border Color
+      * @prop --popupMenuBorderColor: Pop Up Menu Border Color
     */
-    --menuBorderColor: var(--primary);
 
     /**
-      * @prop --menuTextColor: Pop Up Menu Text Color
+      * @prop --popupMenuTextColor: Pop Up Menu Text Color
     */
-    --menuTextColor: var(--primaryElementText);
 
     /**
-      * @prop --menuBorderColor: Pop Up Menu Caret Background Color
+      * @prop --popupCaretBackgroundColor: Pop Up Menu Caret Background Color
     */
-    --popupCaretBackgroundColor: var(--primary);
-
-    /**
-      * @prop --menuItemBackgroundColor: Pop Up Menu Item Background Color
-    */
-    --menuItemBackgroundColor: var(--primary);
-
-    /**
-      * @prop --menuItemHoverBackgroundColor: Pop Up Menu Item Hover Background Color
-    */
-    --menuItemHoverBackgroundColor: var(--primaryLight);
-
-    /**
-      * @prop --menuItemHoverTextColor: Pop Up Menu Item Hover Text Color
-    */
-    --menuItemHoverTextColor: var(--primaryElementText);
 
     /**
       * @prop --caretLeft: Position of Caret
@@ -60,10 +41,10 @@
     position: absolute;
     pointer-events: none;
 
-    color: var(--colorBlack, rgb(0, 0, 0));
+    color: var(--popupMenuTextColor);
 
-    background-color: var(--menuBorderColor);
-    border: 1px solid var(--menuBorderColor);
+    background-color: var(--popupMenuBorderColor);
+    border: 1px solid var(--popupMenuBorderColor);
     border-top-width: 4px;
     z-index: 10000;
 
@@ -106,7 +87,7 @@ ul {
     padding: 0;
     margin: 0;
 
-    background-color: var(--menuBackgroundColor);
+    background-color: var(--popupMenuBackgroundColor);
 
     z-index: 2;
     border-radius: 2px;
@@ -120,11 +101,6 @@ li:last-of-type {
 li:first-of-type {
     border: none;
     border-radius: 2px 2px 0 0;
-}
-
-li:not([role='seperator']):hover {
-    background-color: var(--menuItemHoverBackgroundColor);
-    color: var(--menuItemHoverTextColor);
 }
 
 :host(.from-top) {

--- a/src/components/rux-segmented-button/readme.md
+++ b/src/components/rux-segmented-button/readme.md
@@ -60,16 +60,20 @@ document.addEventListener('change', (e) =>
 
 ## CSS Custom Properties
 
-| Name                                       | Description                                |
-| ------------------------------------------ | ------------------------------------------ |
-| `--segmentedButtonBackgroundColor`         | Segmented button background color          |
-| `--segmentedButtonBorderColor`             | Segmented button border color              |
-| `--segmentedButtonHoverBackgroundColor`    | Segmented button hover background color    |
-| `--segmentedButtonHoverBorderColor`        | Segmented button hover border color        |
-| `--segmentedButtonHoverTextColor`          | Segmented button hover text color          |
-| `--segmentedButtonSelectedBackgroundColor` | Segmented button selected background color |
-| `--segmentedButtonSelectedTextColor`       | Segmented button selected text color       |
-| `--segmentedButtonTextColor`               | Segmented button text color                |
+| Name                                            | Description                                      |
+| ----------------------------------------------- | ------------------------------------------------ |
+| `--segmentedButtonBackgroundColor`              | Segmented button background color                |
+| `--segmentedButtonBorderColor`                  | Segmented button border color                    |
+| `--segmentedButtonHoverBackgroundColor`         | Segmented button hover background color          |
+| `--segmentedButtonHoverBorderColor`             | Segmented button hover border color              |
+| `--segmentedButtonHoverTextColor`               | Segmented button hover text color                |
+| `--segmentedButtonSelectedBackgroundColor`      | Segmented button selected background color       |
+| `--segmentedButtonSelectedBorderColor`          | Segmented button selected border color           |
+| `--segmentedButtonSelectedHoverBackgroundColor` | Segmented button selected hover background color |
+| `--segmentedButtonSelectedHoverBorderColor`     | Segmented button selected hover border color     |
+| `--segmentedButtonSelectedHoverTextColor`       | Segmented button selected hover text color       |
+| `--segmentedButtonSelectedTextColor`            | Segmented button selected text color             |
+| `--segmentedButtonTextColor`                    | Segmented button text color                      |
 
 
 ----------------------------------------------

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -529,10 +529,14 @@ $theme: (
     --segmentedButtonHoverBackgroundColor: var(--backgroundColor);
     --segmentedButtonHoverTextColor: var(--primary);
     --segmentedButtonHoverBorderColor: var(--primaryLight);
-    --segmentedButtonSelectedBackgroundColor: #1c3f5e;
+    --segmentedButtonSelectedBackgroundColor: var(
+        --colorSnowflakesDarkSelected
+    );
     --segmentedButtonSelectedTextColor: var(--defaultText);
     --segmentedButtonSelectedBorderColor: var(--primary);
-    --segmentedButtonSelectedHoverBackgroundColor: #1c3f5e;
+    --segmentedButtonSelectedHoverBackgroundColor: var(
+        --colorSnowflakesDarkSelected
+    );
     --segmentedButtonSelectedHoverTextColor: var(--defaultText);
     --segmentedButtonSelectedHoverBorderColor: var(--primary);
 }

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -81,7 +81,7 @@ $theme: (
 
     --colorPrimaryLighten5: rgb(51, 123, 165);
     --colorPrimaryLighten1: rgb(51, 123, 165);
-    --colorPrimaryLighten2: rgb(102, 156, 188);
+    --colorPrimaryLighten2: rgb(100, 156, 189);
     --colorPrimaryLighten3: rgb(153, 189, 210);
     --colorPrimaryLighten4: rgb(204, 222, 233);
     --colorPrimaryDarken1: rgb(0, 72, 114);
@@ -94,7 +94,7 @@ $theme: (
     --colorSecondaryLighten3: rgb(184, 222, 255);
     --colorSecondaryLighten4: rgb(219, 238, 255);
     --colorSecondaryDarken1: rgb(62, 138, 204);
-    --colorSecondaryDarken2: rgb(46, 103, 153);
+    --colorSecondaryDarken2: rgb(43, 101, 155);
     --colorSecondaryDarken3: rgb(31, 69, 102);
     --colorSecondaryDarken4: rgb(15, 34, 51);
 
@@ -233,6 +233,10 @@ $theme: (
     --colorGrayDarken3: rgb(82, 82, 82);
     --colorGrayDarken4: rgb(41, 41, 41);
 
+    --colorSnowflakesDarkSurface: #1b2d3e;
+    --colorSnowflakesLightShadow: #828181;
+    --colorSnowflakesDarkSelected: #1c3f5e;
+    --colorSnowflakesLightSelected: #cee9fc;
     /*
 
     Global Colors

--- a/src/global/theme/_theme-dark.scss
+++ b/src/global/theme/_theme-dark.scss
@@ -11,7 +11,10 @@
     --defaultText: var(--colorWhite, #ffffff);
     --secondaryText: var(--colorTertiaryLighten4, #d4d8dd);
     --globalAppHeader: var(--colorTertiaryDarken2, #172635);
-    --surfaceElements: #1b2d3e; /* TODO: this is an unofficial Astro color, but a required KM color */
+    --surfaceElements: var(
+        --colorSnowflakesDarkSurface,
+        #1b2d3e
+    ); /* TODO: this is an unofficial Astro color, but a required KM color */
     --primary: var(--colorSecondary, #4dacff);
     --primaryLight: var(--colorSecondaryLighten2, #92cbff);
     --primaryLightHover: #92cbff4d; /* TODO: this is a temporary fix, the use of opacity from Sketch is new and not accounted for in CSS */
@@ -145,12 +148,16 @@
     --segmentedButtonHoverBorderColor: var(--primaryLight);
 
     /* Segmented Selected */
-    --segmentedButtonSelectedBackgroundColor: #1c3f5e;
+    --segmentedButtonSelectedBackgroundColor: var(
+        --colorSnowflakesDarkSelected
+    );
     --segmentedButtonSelectedTextColor: var(--defaultText);
     --segmentedButtonSelectedBorderColor: var(--primary);
 
     /* Segmented Selected & Hover */
-    --segmentedButtonSelectedHoverBackgroundColor: #1c3f5e;
+    --segmentedButtonSelectedHoverBackgroundColor: var(
+        --colorSnowflakesDarkSelected
+    );
     --segmentedButtonSelectedHoverTextColor: var(--defaultText);
     --segmentedButtonSelectedHoverBorderColor: var(--primary);
 

--- a/src/global/theme/_theme-dark.scss
+++ b/src/global/theme/_theme-dark.scss
@@ -183,21 +183,22 @@
     --switchButtonHoverOffColor: var(--primaryLight);
     /*
 
-    Popup Menu Colors
+    Popup Menu Colors & Menu Item/Divider
     ==========================================================================
 
   */
-    --popupMenuBackgroundColor: var(--inputBackground);
-    --popupMenuBorderColor: var(--primary);
-    --popupMenuTextColor: var(--primaryElementText);
+    --popupMenuBackgroundColor: var(--backgroundColor);
+    --popupMenuBorderColor: var(--primaryDarker);
+    --popupMenuTextColor: var(--primary);
 
-    --popupCaretBackgroundColor: var(--primary);
+    --popupCaretBackgroundColor: var(--primaryDarker);
 
-    --popupMenuItemBackgroundColor: var(--primary);
-    --popupMenuItemHoverBackgroundColor: var(--primaryLight);
-    --popupMenuItemHoverTextColor: var(--primaryElementText);
+    --menuItemBackgroundColor: var(--backgroundColor);
+    --menuItemHoverBackgroundColor: rgba(28, 63, 94, 0.3);
+    --menuTextColor: var(--primary);
+    --menuItemHoverTextColor: var(--primary);
 
-    --popupMenuItemSeperatorBorderColor: var(--primaryElementText);
+    --menuItemDividerBorderColor: var(--primary);
 
     /*
 

--- a/src/global/theme/_theme-light.scss
+++ b/src/global/theme/_theme-light.scss
@@ -144,12 +144,16 @@
     --segmentedButtonHoverBorderColor: var(--primaryDark);
 
     /* Segmented Select */
-    --segmentedButtonSelectedBackgroundColor: #cee9fc;
+    --segmentedButtonSelectedBackgroundColor: var(
+        --colorSnowflakesLightSelected
+    );
     --segmentedButtonSelectedTextColor: var(--defaultText);
     --segmentedButtonSelectedHoverBorderColor: var(--primary);
 
     /* Segmented Selected & Hover */
-    --segmentedButtonSelectedHoverBackgroundColor: #cee9fc;
+    --segmentedButtonSelectedHoverBackgroundColor: var(
+        --colorSnowflakesLightSelected
+    );
     --segmentedButtonSelectedHoverTextColor: var(--defaultText);
     --segmentedButtonSelectedHoverBorderColor: var(--primary);
 
@@ -198,7 +202,7 @@
 
     --clockTextColor: var(--primaryElementText);
     --clockBackgroundColor: #101923;
-    --clockBorderColor: #1b2d3e;
+    --clockBorderColor: var(--colorSnowflakesDarkSurface);
     --clockLabelColor: var(--primaryElementText);
 
     /*

--- a/src/global/theme/_theme-light.scss
+++ b/src/global/theme/_theme-light.scss
@@ -181,6 +181,26 @@
 
     /*
 
+    Popup Menu Colors & Menu Item/Divider
+    ==========================================================================
+
+    */
+
+    --popupMenuBackgroundColor: var(--backgroundColor);
+    --popupMenuBorderColor: var(--primaryLighter);
+    --popupMenuTextColor: var(--primary);
+
+    --popupCaretBackgroundColor: var(--primaryLighter);
+
+    --menuItemBackgroundColor: var(--backgroundColor);
+    --menuItemHoverBackgroundColor: rgba(206, 233, 252, 0.3);
+    --menuTextColor: var(--primary);
+    --menuItemHoverTextColor: var(--primaryLight);
+
+    --menuItemDividerBorderColor: var(--primary);
+
+    /*
+
     Push Button Colors
     ==========================================================================
 


### PR DESCRIPTION
## Brief Description

Updates the popup component to use new values for custom css properties and removes properties from pop up component that are handled by menu item component.

## JIRA Link

[https://rocketcom.atlassian.net/browse/ASTRO-1568](https://rocketcom.atlassian.net/browse/ASTRO-1568)

## Related Issue

We may want to separate out the properties for menu-item and menu-divider but as of now the only place the component is used is in the pop up menu. 

## General Notes

Dark Theme Changes:

    --popupMenuBackgroundColor: var(--inputBackground >>> var(--backgroundColor);
    --popupMenuBorderColor: var(--primary) >>> var(--primaryDarker);
    --popupMenuTextColor: var(--primaryElementText) >>> var(primary);

    --popupCaretBackgroundColor: var(--primary) >>> var(--primaryDarker);

    --menuItemBackgroundColor: var(--backgroundColor);
    --menuItemHoverBackgroundColor: rgba(28, 63, 94, 0.3);
    --menuTextColor: var(--primary);
    --menuItemHoverTextColor: var(--primary);

    --menuItemDividerBorderColor: var(--primary);

Light Theme Changes (variables did not previously exist): 

    --popupMenuBackgroundColor: var(--backgroundColor);
    --popupMenuBorderColor: var(--primaryLighter);
    --popupMenuTextColor: var(--primary);

    --popupCaretBackgroundColor: var(--primaryLighter);

    --menuItemBackgroundColor: var(--backgroundColor);
    --menuItemHoverBackgroundColor: rgba(206, 233, 252, 0.3);
    --menuTextColor: var(--primary);
    --menuItemHoverTextColor: var(--primaryLight);

    --menuItemDividerBorderColor: var(--primary);


Other Changes:

` --menuItemDividerBorderColor: var(--primaryElementText) >>> var(--primary)
`
## Motivation and Context

This brings the component up-to-date with new KM guidelines.

## Issues and Limitations

I was unable to use a custom property for the menu item hover state background since none of the css functions that I tried to add opacity with would compile right from scss to css. I therefore resorted to using an rgba value. 

Just as in segment-button update I had to remove the custom props from the component as they were not being overwritten by the theme files. 

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
