### PR TITLE
Fix: Astro 1521 progress nan

### DIFF
--- a/src/components/rux-progress/rux-progress.tsx
+++ b/src/components/rux-progress/rux-progress.tsx
@@ -20,6 +20,11 @@ export class RuxProgress {
     @Prop({ attribute: 'hide-label', mutable: true }) hideLabel: boolean = false
 
     getProgressAsString() {
+        // If max = '', just return the value.
+        if (!this.max) {
+            return this.value
+        }
+
         if (this.value === undefined) {
             return '0%'
         } else {
@@ -29,7 +34,7 @@ export class RuxProgress {
         }
     }
     checkValueNotOverMax(max: number, value: number) {
-        if (max < value) {
+        if (max && max < value) {
             max = value
             this.max = max
             console.warn(

--- a/src/components/rux-progress/test/rux-progress.spec.tsx
+++ b/src/components/rux-progress/test/rux-progress.spec.tsx
@@ -58,4 +58,22 @@ describe('rux-progress', () => {
         </rux-progress>
       `)
     })
+
+    it('only renders the value if max is set to ""', async () => {
+        const page = await newSpecPage({
+            components: [RuxProgress],
+            html: `<rux-progress value="20" max="100"></rux-progress>`,
+        })
+        await page?.root?.setAttribute('max', '')
+        await page.waitForChanges()
+        expect(page.root).toEqualHtml(`
+      <rux-progress max="" value="20">
+        <mock:shadow-root>
+        <progress class="rux-progress" value="20" max="NaN"></progress>
+        <output class="rux-progress__value">20</output>
+          <slot></slot>
+        </mock:shadow-root>
+      </rux-progress>
+    `)
+    })
 })


### PR DESCRIPTION
## Brief Description

If 'max' is set to '', component renders NaN as the progress string.
Added test case

## JIRA Link

[ASTRO-1521](https://rocketcom.atlassian.net/browse/ASTRO-1521)

## Issues and Limitations

* NaN can still get reflected back to max in testing because it's mutable. Will open a separate PR for that .

## Types of changes

-   [x] Bug fix

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
