### PR TITLE
Astro 1527 km input update

### DIFF
--- a/src/components/rux-input-field/rux-input-field.scss
+++ b/src/components/rux-input-field/rux-input-field.scss
@@ -44,8 +44,7 @@
         width: 100%;
         padding: 0 0.625rem;
         border: 1px solid var(--inputBorderColor);
-        border-radius: 4px;
-        font-size: 1rem;
+        border-radius: 3px;
         font-size: var(--fontSize, 1rem);
         color: var(--inputTextColor);
         background-color: var(--inputBackgroundColor);
@@ -72,6 +71,13 @@
             border-color: var(--inputFocusBorderColor);
             outline: none;
             color: var(--inputFocusTextColor);
+        }
+        &::placeholder {
+            font-size: 1rem;
+            font-weight: normal;
+            font-family: var(--fontFamily);
+            color: var(--defaultText);
+            opacity: 0.6;
         }
     }
 

--- a/src/components/rux-input-field/rux-input-field.scss
+++ b/src/components/rux-input-field/rux-input-field.scss
@@ -15,6 +15,9 @@
     * @prop --inputFocusTextColor: the input focus text color
     */
     /**
+    * @prop --inputSelectionBackgroundColor: the background color of highlighted text
+    */
+    /**
     * @prop --inputInvalidBorderColor: the input invalid border color
     */
     /**

--- a/src/components/rux-input-field/rux-input-field.scss
+++ b/src/components/rux-input-field/rux-input-field.scss
@@ -45,6 +45,7 @@
         font-size: 1rem;
         font-size: var(--fontSize, 1rem);
         color: var(--inputTextColor);
+        background-color: var(--inputBackgroundColor);
         &--invalid {
             border: 1px solid var(--inputInvalidBorderColor);
         }
@@ -61,6 +62,22 @@
             background: var(--inputBackgroundColor) var(--inputSearchIcon) 10px/0.975rem
                 no-repeat;
         }
+    }
+
+    .rux-input {
+        &:focus {
+            border-color: var(--inputFocusBorderColor);
+            outline: none;
+            color: var(--inputFocusTextColor);
+        }
+    }
+
+    .rux-input-label {
+        margin-bottom: 0.375rem;
+    }
+
+    ::selection {
+        background-color: var(--inputSelectionBackgroundColor);
     }
 
     .rux-form-field--small {

--- a/src/components/rux-textarea/rux-textarea.scss
+++ b/src/components/rux-textarea/rux-textarea.scss
@@ -12,6 +12,7 @@
         font-family: var(--fontFamily);
         font-size: var(--fontSize, 1rem);
         color: var(--inputTextColor);
+        background-color: var(--inputBackgroundColor);
         &--invalid {
             border: 1px solid var(--inputInvalidBorderColor);
         }
@@ -30,6 +31,22 @@
         font-family: var(--fontFamily);
         font-size: var(--fontSize);
         color: var(--fontColor);
+    }
+
+    .rux-textarea {
+        &:focus {
+            border-color: var(--inputFocusBorderColor);
+            outline: none;
+            color: var(--inputFocusTextColor);
+        }
+    }
+
+    .rux-textarea-label {
+        margin-bottom: 0.375rem;
+    }
+
+    ::selection {
+        background-color: var(--inputSelectionBackgroundColor);
     }
 
     .rux-textarea-field--small {

--- a/src/components/rux-textarea/rux-textarea.scss
+++ b/src/components/rux-textarea/rux-textarea.scss
@@ -39,6 +39,13 @@
             outline: none;
             color: var(--inputFocusTextColor);
         }
+        &::placeholder {
+            font-size: 1rem;
+            font-weight: normal;
+            font-family: var(--fontFamily);
+            color: var(--defaultText);
+            opacity: 0.6;
+        }
     }
 
     .rux-textarea-label {

--- a/src/components/rux-textarea/rux-textarea.tsx
+++ b/src/components/rux-textarea/rux-textarea.tsx
@@ -124,7 +124,7 @@ export class RuxTextarea {
                         value={this.value}
                         class={{
                             'rux-textarea': true,
-                            'rux-textrea--disabled': this.disabled,
+                            'rux-textarea--disabled': this.disabled,
                             'rux-textarea--invalid': this.invalid,
                         }}
                         id={this.inputId}

--- a/src/global/theme/_theme-dark.scss
+++ b/src/global/theme/_theme-dark.scss
@@ -330,20 +330,21 @@
 
   */
 
-    --inputBackgroundColor: var(--inputBackground);
-    --inputBorderColor: var(--surfaceElements);
-    --inputBorderColorAlt: var(--inputDark);
-    --inputBorderColorDisabled: #292a2d;
-    --inputTextColor: var(--primaryElementText);
+    --inputBackgroundColor: var(--colorTertiaryDarken3);
+    --inputBorderColor: var(--colorSecondaryDarken2);
+    --inputBorderColorAlt: var(--colorTertiaryDarken4);
+    --inputTextColor: var(--defaultText);
 
     /* Input Focus */
-    --inputFocusBorderColor: var(--primary);
-    --inputFocusTextColor: var(--primaryElementText);
+    --inputFocusBorderColor: var(--colorSecondaryLighten2);
+    --inputFocusTextColor: var(--defaultText);
+
+    --inputSelectionBackgroundColor: var(--colorSnowflakesDarkSelected);
 
     --inputInvalidBorderColor: var(--colorCritical);
 
-    --inputSearchIcon: url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%23005a92' fill-rule='evenodd'/%3E%3C/svg%3E");
-    --inputSearchCancel: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%233a87cf' fill-rule='evenodd' d='M69.028 64l22.628 22.627-5.029 5.029L64 69.028 41.373 91.656l-5.029-5.029L58.972 64 36.344 41.373l5.029-5.029L64 58.972l22.627-22.628 5.029 5.029L69.028 64z'/%3E%3C/svg%3E");
+    --inputSearchIcon: url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%234dacff' fill-rule='evenodd'/%3E%3C/svg%3E");
+    --inputSearchCancel: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%234dacff' fill-rule='evenodd' d='M69.028 64l22.628 22.627-5.029 5.029L64 69.028 41.373 91.656l-5.029-5.029L58.972 64 36.344 41.373l5.029-5.029L64 58.972l22.627-22.628 5.029 5.029L69.028 64z'/%3E%3C/svg%3E");
 
     /*
 

--- a/src/global/theme/_theme-dark.scss
+++ b/src/global/theme/_theme-dark.scss
@@ -330,13 +330,13 @@
 
   */
 
-    --inputBackgroundColor: var(--colorTertiaryDarken3);
-    --inputBorderColor: var(--colorSecondaryDarken2);
-    --inputBorderColorAlt: var(--colorTertiaryDarken4);
+    --inputBackgroundColor: var(--backgroundColor);
+    --inputBorderColor: var(--primaryDarker);
+    --inputBorderColorAlt: var(--inputDark);
     --inputTextColor: var(--defaultText);
 
     /* Input Focus */
-    --inputFocusBorderColor: var(--colorSecondaryLighten2);
+    --inputFocusBorderColor: var(--primaryLight);
     --inputFocusTextColor: var(--defaultText);
 
     --inputSelectionBackgroundColor: var(--colorSnowflakesDarkSelected);

--- a/src/global/theme/_theme-light.scss
+++ b/src/global/theme/_theme-light.scss
@@ -328,12 +328,12 @@
 
   */
 
-    --inputBackgroundColor: var(--colorQuaternaryLighten3);
-    --inputBorderColor: var(--colorPrimaryLighten2);
-    --inputBorderColorAlt: var(--colorTertiaryDarken4);
+    --inputBackgroundColor: var(--backgroundColor);
+    --inputBorderColor: var(--primaryLighter);
+    --inputBorderColorAlt: var(--inputDark);
     --inputTextColor: var(--defaultText);
 
-    --inputFocusBorderColor: var(--colorPrimaryDarken1);
+    --inputFocusBorderColor: var(--primaryDark);
     --inputFocusTextColor: var(--defaultText);
 
     --inputSelectionBackgroundColor: var(--colorSecondaryLighten3);

--- a/src/global/theme/_theme-light.scss
+++ b/src/global/theme/_theme-light.scss
@@ -18,7 +18,7 @@
     --primaryDarkHover: #0048724d; /* TODO: this is a temporary fix, the use of opacity from Sketch is new and not accounted for in CSS */
     --primaryElementText: var(--colorWhite, #ffffff);
     --inputBackground: var(--colorWhite, #ffffff);
-    --inputDark: #080c11;
+    --inputDark: var(--colorTertiaryDarken4, #080c11);
 
     /* styles */
     --fontColor: var(--defaultText);
@@ -328,19 +328,20 @@
 
   */
 
-    --inputBackgroundColor: var(--inputBackground);
-    --inputBorderColor: var(--primaryLight);
-    --inputBorderColorAlt: var(--inputDark);
-    --inputBorderColorDisabled: #292a2d;
+    --inputBackgroundColor: var(--colorQuaternaryLighten3);
+    --inputBorderColor: var(--colorPrimaryLighten2);
+    --inputBorderColorAlt: var(--colorTertiaryDarken4);
     --inputTextColor: var(--defaultText);
 
-    --inputFocusBorderColor: var(--primary);
+    --inputFocusBorderColor: var(--colorPrimaryDarken1);
     --inputFocusTextColor: var(--defaultText);
+
+    --inputSelectionBackgroundColor: var(--colorSecondaryLighten3);
 
     --inputInvalidBorderColor: var(--colorCritical);
 
-    --inputSearchIcon: url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%233a87cf' fill-rule='evenodd'/%3E%3C/svg%3E");
-    --inputSearchCancel: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23004872' fill-rule='evenodd' d='M69.028 64l22.628 22.627-5.029 5.029L64 69.028 41.373 91.656l-5.029-5.029L58.972 64 36.344 41.373l5.029-5.029L64 58.972l22.627-22.628 5.029 5.029L69.028 64z'/%3E%3C/svg%3E");
+    --inputSearchIcon: url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M35.37 26.457a15.282 15.282 0 000-21.918c-6.176-6.052-16.187-6.052-22.361 0a15.274 15.274 0 00-1.541 20.166c-.367.147-.713.37-1.014.665L.926 34.709a3.056 3.056 0 000 4.383 3.208 3.208 0 004.472 0l9.528-9.339c.352-.345.604-.753.756-1.186 6.137 3.831 14.347 3.124 19.687-2.11zM24.193 4.043c6.454 0 11.686 5.129 11.686 11.455 0 6.326-5.232 11.455-11.686 11.455-6.455 0-11.687-5.129-11.687-11.455 0-6.326 5.232-11.455 11.687-11.455z' fill='%23005a8f' fill-rule='evenodd'/%3E%3C/svg%3E");
+    --inputSearchCancel: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23005a8f' fill-rule='evenodd' d='M69.028 64l22.628 22.627-5.029 5.029L64 69.028 41.373 91.656l-5.029-5.029L58.972 64 36.344 41.373l5.029-5.029L64 58.972l22.627-22.628 5.029 5.029L69.028 64z'/%3E%3C/svg%3E");
 
     /*
 


### PR DESCRIPTION
## Brief Description

Adds the Kobayashi Maru style changes to the input and text area components.

## JIRA Link

[ASTRO-1527](https://rocketcom.atlassian.net/browse/ASTRO-1527)

## Related Issue

[Corresponding LitElement Repo PR](https://github.com/RocketCommunicationsInc/astro-components/pull/155)

## General Notes

A few new rules to cover focus and selection pseudo classes had to be created. All colors were switched to using global theme variables when possible

## Motivation and Context

KM guidance

## Issues and Limitations

I cam across a possible accessibility issue in Chrome. The chrome user-agent styles for input:focus are also adding the rules for input:focus-visible. Usually :focus is for when a user clicks on the input and :focus-visible is for when a user or assistive device tabs into an input. However Chrome has decided to treat them the same which by default puts a very prominent orange outline around the input. Our input:focus styling changes that outline to none in order to show our light blue border upon mouse click. This effectively eliminates the :focus-visible styling and makes it the same as our :focus state. Just something to keep in mind if we want to differentiate between a :focus and :focus-visible state in the future. 

## Types of changes

-   [ ] Bug fix
-   [X] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
