### PR TITLE
fix(rux-monitoring-icon): fix test

### DIFF
--- a/src/components/rux-monitoring-icon/test/rux-monitoring-icon.spec.tsx
+++ b/src/components/rux-monitoring-icon/test/rux-monitoring-icon.spec.tsx
@@ -18,7 +18,9 @@ describe('rux-monitoring-icon', () => {
         <mock:shadow-root>
          <div class="rux-advanced-status" id="rux-advanced-status__icon" title="10210 Altitude for satellite X 100000m">
            <div class="rux-advanced-status__icon-group">
+           <div class="rux-advanced-status__status">
              <rux-status status="standby"></rux-status>
+             </div>
              <rux-icon class="rux-status--standby" icon="altitude"></rux-icon>
              <div class="rux-advanced-status__badge">
                10K


### PR DESCRIPTION
## Brief Description

Fixes failing monitoring icon unit test from https://github.com/RocketCommunicationsInc/astro-components-stencil/pull/73

## Types of changes

-   [x] Bug fix

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
