### PR TITLE
Prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "build": "stencil build --docs",
         "start": "stencil build --dev --watch --serve",
-        "test": "TZ=UTC stencil test --spec",
+        "test": "npm run test.spec",
         "cy.open": "cypress open",
         "cy.run": "cypress run",
         "cy.start-storybook": "start-storybook -p 6060 -s ./dist -c .storybook-next",
@@ -36,7 +36,8 @@
         "build-astro-prod": "npm run build && npm run build-storybook",
         "prettier": "prettier --write --loglevel warn .",
         "pretty-quick": "pretty-quick --staged",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "prepack": "npm run build"
     },
     "dependencies": {
         "@stencil/core": "~2.5.2",


### PR DESCRIPTION
## Brief Description

To remove a step in the publish process I added the prepack script. It runs the Stencil build before NPM packages are built.

## JIRA Link

N/A

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
