### PR TITLE
feat(rux-button): align button sizes to design

### DIFF
--- a/src/components/rux-button/rux-button.scss
+++ b/src/components/rux-button/rux-button.scss
@@ -71,7 +71,6 @@
 
     height: 2.125rem;
     min-width: 2.25rem;
-    /* max-width: 10.125rem; */
 
     border-radius: var(--buttonBorderRadius);
 
@@ -201,8 +200,6 @@
         .rux-button__icon {
             height: 1rem;
             width: 1rem;
-            // margin-left: -0.8rem;
-            /* margin: -0.65rem 0.25rem -0.3rem calc((1.5rem - 0.625rem) * -1); */
         }
     }
 
@@ -255,7 +252,6 @@
 .rux-button--large rux-icon {
     height: 1rem;
     width: 1rem;
-    // margin-left: -1rem;
 }
 
 .rux-button rux-icon {

--- a/src/components/rux-button/rux-button.scss
+++ b/src/components/rux-button/rux-button.scss
@@ -90,10 +90,9 @@
 
     ::slotted(rux-icon),
     rux-icon {
-        height: 1.5rem;
-        width: 1.5rem;
+        height: 1rem;
+        width: 1rem;
         margin-right: 0.625rem;
-        margin-left: -0.625rem;
     }
 
     &:disabled {
@@ -170,10 +169,13 @@
     }
 
     &--small {
-        font-size: var(--smallLabelFontSize);
         height: 1.625rem;
         padding: 0 1rem;
         line-height: 1;
+        .rux-button--icon-only {
+            width: 3rem;
+            height: 1.625rem;
+        }
 
         &.rux-button {
             &__icon {
@@ -189,14 +191,17 @@
     }
 
     &--large {
-        font-size: var(--largeLabelFontSize);
         height: 2.875rem;
         min-width: 3rem;
         padding: 0 1rem;
+        .rux-button--icon-only {
+            width: 3rem;
+            height: 2.875rem;
+        }
         .rux-button__icon {
-            height: 1.75rem;
-            width: 1.75rem;
-            margin-left: -0.8rem;
+            height: 1rem;
+            width: 1rem;
+            // margin-left: -0.8rem;
             /* margin: -0.65rem 0.25rem -0.3rem calc((1.5rem - 0.625rem) * -1); */
         }
     }
@@ -214,6 +219,8 @@
 
     &--icon-only {
         font-size: 0px;
+        width: 3rem;
+        hieght: 2.125rem;
         .rux-button__icon {
             margin-left: -0.625rem;
             margin-right: -0.625rem;
@@ -240,15 +247,15 @@
 
 .rux-button--small ::slotted(rux-icon),
 .rux-button--small rux-icon {
-    height: 0.875rem;
-    width: 0.875rem;
+    height: 1rem;
+    width: 1rem;
 }
 
 .rux-button--large ::slotted(rux-icon),
 .rux-button--large rux-icon {
-    height: 1.75rem;
-    width: 1.75rem;
-    margin-left: -0.8rem;
+    height: 1rem;
+    width: 1rem;
+    // margin-left: -1rem;
 }
 
 .rux-button rux-icon {


### PR DESCRIPTION
## Brief Description

Button font size should not change on small/large variants.
Change Icon Only buttons to match design files more closely.

## JIRA Link

[ASTRO-1576](https://rocketcom.atlassian.net/browse/ASTRO-1576)
[ASTRO-1572](https://rocketcom.atlassian.net/browse/ASTRO-1572)

## Motivation and Context

Porting recent changes to Lit library over to Stencil

## Types of changes

-   [x] New feature

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
