### PR TITLE
fix: added padding-left of 1 percent on switch

### DIFF
--- a/src/components/rux-switch/rux-switch.scss
+++ b/src/components/rux-switch/rux-switch.scss
@@ -15,6 +15,7 @@
     /**
       * @prop --switchOffBorderColor: the Switch off border color
       */
+    padding-left: 1%;
 }
 
 .rux-switch {

--- a/src/stories/rux-switch.stories.tsx
+++ b/src/stories/rux-switch.stories.tsx
@@ -18,6 +18,7 @@ export const Switch = () => {
                 .disabled=${disabled}
                 .checked=${checked}
                 id="01"
+                style="padding-left: 0%;"
             ></rux-switch>
         </div>
     `


### PR DESCRIPTION
## Brief Description

Added `padding-left: 1%` to the rux-switch in order to keep it rendering inside of it's parent. 

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1631
## Related Issue

## General Notes

On the storybook switch, changed the padding back to 0 to pass regressions. 

## Motivation and Context

Keeps the rux-switch from rendering outside it's parent component. 

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
