### PR TITLE
Astro 1662 switch disabled

### DIFF
--- a/src/components/rux-switch/rux-switch.tsx
+++ b/src/components/rux-switch/rux-switch.tsx
@@ -67,7 +67,6 @@ export class RuxSwitch {
                         name={name}
                         role="switch"
                         disabled={disabled}
-                        aria-disabled={disabled ? 'true' : 'false'}
                         checked={checked}
                         onClick={(e) => this.handleClick(e)}
                     />

--- a/src/components/rux-switch/rux-switch.tsx
+++ b/src/components/rux-switch/rux-switch.tsx
@@ -25,7 +25,7 @@ export class RuxSwitch {
      * Button takes on a distinct visual state.
      * Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored.
      */
-    @Prop() disabled: boolean = false
+    @Prop({ reflect: true }) disabled: boolean = false
 
     /**
      * Checks the button via HTML `checked` attribute. Button takes on a distinct "enabled" or "selected" visual state.
@@ -54,7 +54,6 @@ export class RuxSwitch {
         const { inputId, name, disabled, checked } = this
         return (
             <Host
-                onClick={this.handleClick}
                 aria-checked={`${checked}`}
                 aria-hidden={disabled ? 'true' : null}
                 role="switch"
@@ -68,7 +67,9 @@ export class RuxSwitch {
                         name={name}
                         role="switch"
                         disabled={disabled}
+                        aria-disabled={disabled ? 'true' : 'false'}
                         checked={checked}
+                        onClick={(e) => this.handleClick(e)}
                     />
                     <label class="rux-switch__button" htmlFor={inputId}></label>
                 </div>


### PR DESCRIPTION
## Brief Description
The onClick method for rux-switch used to be on Host and thus would trigger if you clicked anywhere on Host. This also made it ignore the disabled prop, and so it could be toggled even when disabled. Moved the onclick to the <input>, and changed its call to be `(e) => this.handleClick(e)` in order for it to work there. Switch can no longer be toggled by clicking it if it is disabled. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1662

## Related Issue

## General Notes

I also changed the disabled prop to have `reflect: true` to match our other input components. 

## Motivation and Context

Removes the onClick from <Host> so that 1) you have to click on the switch to trigger, not just Host 2) No longer allows switch to be toggled when in a disabled state

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
