### PR TITLE
ASTRO-1678 rux-push-button event update

### DIFF
--- a/src/components/rux-push-button/rux-push-button.tsx
+++ b/src/components/rux-push-button/rux-push-button.tsx
@@ -20,7 +20,7 @@ export class RuxPushButton {
      * Button takes on a distinct disabled visual state.
      * Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored.
      */
-    @Prop() disabled: boolean = false
+    @Prop({ reflect: true }) disabled: boolean = false
     /**
      * Checks the push button via HTML `checked` attribute.
      * Push button takes on a distinct "enabled" or "selected" visual state.
@@ -40,7 +40,6 @@ export class RuxPushButton {
 
     handleClick(event: MouseEvent) {
         event.preventDefault()
-        if (this.disabled) return
         this.checked = !this.checked
     }
 
@@ -64,6 +63,7 @@ export class RuxPushButton {
                     type="checkbox"
                     disabled={disabled}
                     checked={checked}
+                    onClick={(e) => this.handleClick(e)}
                 />
                 <label
                     class="rux-push-button__button"


### PR DESCRIPTION
## Brief Description

Implements solution from [PR #98 ](https://github.com/RocketCommunicationsInc/astro-components-stencil/pull/98)

## JIRA Link
[ASTRO-1678](https://rocketcom.atlassian.net/browse/ASTRO-1678)

## Motivation and Context

Previous version had the handleClick method returning if the disabled prop was set. This new solution removes the need for that check in the handleClick method and takes into consideration the host elements role in the component. 

## Issues and Limitations

## Types of changes

-   [X] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
