### PR TITLE
fix: hide help text if error text exists

### DIFF
--- a/src/components/rux-input-field/rux-input-field.tsx
+++ b/src/components/rux-input-field/rux-input-field.tsx
@@ -148,7 +148,7 @@ export class RuxInputField {
                     ></input>
                 </div>
 
-                {this.helpText && (
+                {this.helpText && !this.errorText && (
                     <div class="rux-help-text">{this.helpText}</div>
                 )}
 

--- a/src/components/rux-textarea/rux-textarea.tsx
+++ b/src/components/rux-textarea/rux-textarea.tsx
@@ -134,7 +134,7 @@ export class RuxTextarea {
                     ></textarea>
                 </div>
 
-                {this.helpText && (
+                {this.helpText && !this.errorText && (
                     <div class="rux-help-text">{this.helpText}</div>
                 )}
 


### PR DESCRIPTION
## Brief Description

Hide help text when error text is present on Input Field and Textarea

## JIRA Link

[ASTRO-1610](https://rocketcom.atlassian.net/browse/ASTRO-1610)

## Issues

Tried to write a test to cover this but it looks like there's an issue with Storybook not passing in args to the controls via query params that we'll need to look into. 

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
