### PR TITLE
Astro 1560 required input fix

### DIFF
--- a/src/components/rux-input-field/rux-input-field.scss
+++ b/src/components/rux-input-field/rux-input-field.scss
@@ -95,6 +95,9 @@
 
     .rux-input-label {
         margin-bottom: 0.375rem;
+        &__asterisk {
+            margin-left: 4px;
+        }
     }
 
     ::selection {

--- a/src/components/rux-input-field/rux-input-field.tsx
+++ b/src/components/rux-input-field/rux-input-field.tsx
@@ -124,6 +124,9 @@ export class RuxInputField {
                 >
                     <label class="rux-input-label" htmlFor={this.inputId}>
                         {this.label}
+                        {this.required && (
+                            <span class="rux-input-label__asterisk">*</span>
+                        )}
                     </label>
                     <input
                         name={this.name}

--- a/src/stories/rux-form-elements.stories.tsx
+++ b/src/stories/rux-form-elements.stories.tsx
@@ -51,7 +51,7 @@ export const InputFields = () => html`
           <rux-input-field placeholder="Text input" label="Text input" help-text="Help text"></rux-input-field>
         </li>
         <li>
-          <rux-input-field value=" " label="Is Required" required></rux-input-field>
+          <rux-input-field value=" " label="Is required" required></rux-input-field>
         </li>
         <li>
           <rux-input-field label="Invalid" error-text="Error text" invalid="true"></rux-input-field>
@@ -147,7 +147,7 @@ export const InputFields = () => html`
           <rux-input-field label="Smaller number input" type="number" placeholder="Number Input" small></rux-input-field>
         </li>
         <li class="rux-form-field rux-form-field--small">
-          <rux-input-field label="Smaller Is Required" required small></rux-input-field>
+          <rux-input-field label="Smaller is required" required small></rux-input-field>
         </li>
         <li class="rux-form-field rux-form-field--small">
           <rux-input-field label="Smaller invalid" invalid error-text="Error text" small></rux-input-field>


### PR DESCRIPTION
## Brief Description

Fixes a capitalization error in the rux-input story and adds a conditional asterisk within each Input label element dependent on the required prop. 

## JIRA Link

[ASTRO-1560](https://rocketcom.atlassian.net/secure/RapidBoard.jspa?rapidView=77&projectKey=ASTRO&modal=detail&selectedIssue=ASTRO-1560)

## Related Issue

This ticket did bring up the idea of creating a label component that can be used throughout Astro but would be out of scope at this time but worth considering.

## Motivation and Context

Follow [Figma Style guidelines](https://www.figma.com/file/ZtHeSWpISd8hJjN46uY9pm/Astro-UX-Design-System?node-id=261%3A1570)

## Types of changes

-   [X] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
