### PR TITLE
fix: can no longer check two radios using js

### DIFF
--- a/src/components/rux-radio/rux-radio.tsx
+++ b/src/components/rux-radio/rux-radio.tsx
@@ -6,6 +6,7 @@ import {
     EventEmitter,
     Element,
     Listen,
+    Watch,
 } from '@stencil/core'
 
 let id = 0
@@ -84,9 +85,27 @@ export class RuxRadio {
         }
     }
 
+    @Watch('checked')
+    handleWatch() {
+        this.checkMultipleChecks()
+    }
+
+    checkMultipleChecks() {
+        const radioSiblings = document.querySelectorAll(
+            `rux-radio[name='${this.el.getAttribute('name')}']`
+        )
+        if (this.checked) {
+            radioSiblings.forEach((sib) => {
+                if (sib.getAttribute('value') != this.value) {
+                    sib.removeAttribute('checked')
+                }
+            })
+        }
+    }
     componentWillLoad() {
         this.onChange = this.onChange.bind(this)
         this.onInput = this.onInput.bind(this)
+        this.checkMultipleChecks()
     }
 
     private onChange(e: Event): void {


### PR DESCRIPTION
## Brief Description

Adds protection against any outside JS causing there to be 2 radio buttons selected at any one time (buttons with the same name prop) 
Here is the code that was used in index.tsx to test this in case anyone wants to try it out and make sure it works: 
```
<form>
<rux-radio id="first" value="green" name="color">green</rux-radio>
<rux-radio id="second" checked value="red" name="color">red</rux-radio>
<rux-radio id="third" value="blue" name="color">blue</rux-radio>
</form>

<script>
const first = document.querySelector('#first')
first.checked = true
</script>
```
I also tested finding and changing one of the radio buttons to be selected, and making sure that only one is still selected at at a time.

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1658

## Related Issue

## General Notes

Created a new method, `checkForMultipleChecks` that only allows one of the radios to be checked at a time, grouping them based off of the radio name prop. This works very similar to the Listen('click') that Sasha was already using.
Also added an @Watch('checked'), which will call the new method above. 

## Motivation and Context

Before this, you could edit the checked prop of a radio button through a script or in the console and therefore create a situation with 2 checked radio's. 

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

(yes i did make a pr to main on accident first)