### PR TITLE
docs: cherry picking icons

### DIFF
--- a/src/stories-next/button.stories.mdx
+++ b/src/stories-next/button.stories.mdx
@@ -301,7 +301,11 @@ If you're already utilizing a build system that supports tree shaking and want t
 
 ```js
 import { RuxButton } from 'astro-web-components/dist/components/rux-button'
-import { RuxIcon } from 'astro-web-components/dist/components/rux-icon'
 customElements.define('rux-button', RuxButton)
-customElements.define('rux-icon', RuxIcon)
+
+// If using an icon
+// import { RuxIcon } from 'astro-web-components/dist/components/rux-icon'
+// Import the specific icon being used
+// customElements.define('rux-icon', RuxIcon)
+// customElements.define('rux-icon-*', RuxIcon*)
 ```

--- a/src/stories-next/icon-and-symbols.stories.mdx
+++ b/src/stories-next/icon-and-symbols.stories.mdx
@@ -150,4 +150,13 @@ export const AllIcons = (args) => {
 </Canvas>
 
 ### Cherry Picking
-Coming Soon
+
+When cherry picking icons, you'll need to register both RuxIcon and any individual icons you wish to use.
+For example, if you wanted to use `rux-icon-close` you would import the following:
+
+```js
+import { RuxIcon } from '@astrouxds/astro-web-components/dist/components/rux-icon'
+import { RuxIconClose } from '@astrouxds/astro-web-components/dist/components/rux-icon-close'
+customElements.define('rux-icon', RuxIcon)
+customElements.define('rux-icon-close', RuxIconClose)
+```

--- a/src/stories-next/notification.stories.mdx
+++ b/src/stories-next/notification.stories.mdx
@@ -139,5 +139,9 @@ If you're already utilizing a build system that supports tree shaking and want t
 
 ```js
 import { RuxNotification } from '@astrouxds/astro-web-components/dist/components/rux-notification'
+import { RuxIcon } from '@astrouxds/astro-web-components/dist/components/rux-icon'
+import { RuxIconClose } from '@astrouxds/astro-web-components/dist/components/rux-icon-close'
 customElements.define('rux-notification', RuxNotification)
+customElements.define('rux-icon', RuxIcon)
+customElements.define('rux-icon-close', RuxIconClose)
 ```


### PR DESCRIPTION
## Brief Description

Adds documentation on how to cherry pick icons

## JIRA Link

[ASTRO-1518](https://rocketcom.atlassian.net/browse/ASTRO-1518)

## Issues and Limitations

Originally made a bunch of changes to the individual icons so that they would have the same API as rux-icon and could be used independently. However, in order for that to work, I had to make certain tradeoffs that made them less customizable using plain css. The trade off wasn't worth it. When cherry picking all you need to do is import RuxIcon along any other individual icons you want. 

## Types of changes

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
