### PR TITLE
fix: remove async from cypress tests

### DIFF
--- a/src/components/rux-button-group/test/rux-button-group.e2e.js
+++ b/src/components/rux-button-group/test/rux-button-group.e2e.js
@@ -2,7 +2,7 @@ describe('Button Group', () => {
     beforeEach(() => {
         cy.visitStory('components-button-group--button-group')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-button-group').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-button/test/rux-button.e2e.js
+++ b/src/components/rux-button/test/rux-button.e2e.js
@@ -2,7 +2,7 @@ describe('Button', () => {
     beforeEach(() => {
         cy.visitStory('components-button--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-button').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-checkbox/test/rux-checkbox.e2e.js
+++ b/src/components/rux-checkbox/test/rux-checkbox.e2e.js
@@ -1,8 +1,8 @@
 describe('Checkbox', () => {
     beforeEach(() => {
-        cy.visitStory('components-form-elements--checkboxes')
+        cy.visitStory('components-checkbox--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-checkbox').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-classification-marking/test/rux-classification-marking.e2e.js
+++ b/src/components/rux-classification-marking/test/rux-classification-marking.e2e.js
@@ -2,7 +2,7 @@ describe('Classificaton Marking', () => {
     beforeEach(() => {
         cy.visitStory('components-classification-markings--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-classification-marking').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-clock/test/rux-clock.e2e.js
+++ b/src/components/rux-clock/test/rux-clock.e2e.js
@@ -2,7 +2,7 @@ describe('Clock', () => {
     beforeEach(() => {
         cy.visitStory('components-clock--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-clock').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-global-status-bar/test/rux-global-status-bar.e2e.js
+++ b/src/components/rux-global-status-bar/test/rux-global-status-bar.e2e.js
@@ -2,7 +2,7 @@ describe('Global Status Bar', () => {
     beforeEach(() => {
         cy.visitStory('components-global-status-bar--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-global-status-bar').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-icon/test/rux-icon.e2e.js
+++ b/src/components/rux-icon/test/rux-icon.e2e.js
@@ -2,7 +2,7 @@ describe('Icon', () => {
     beforeEach(() => {
         cy.visitStory('components-icons--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-icon').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-input-field/test/rux-input-field.e2e.js
+++ b/src/components/rux-input-field/test/rux-input-field.e2e.js
@@ -2,7 +2,7 @@ describe('Input Field', () => {
     beforeEach(() => {
         cy.visitStory('components-input-field--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-input-field').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-log/test/rux-log.e2e.js
+++ b/src/components/rux-log/test/rux-log.e2e.js
@@ -2,7 +2,7 @@ describe('Log', () => {
     beforeEach(() => {
         cy.visitStory('components-log--log')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-log').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-modal/test/rux-modal.e2e.js
+++ b/src/components/rux-modal/test/rux-modal.e2e.js
@@ -2,7 +2,7 @@ describe('Modal', () => {
     beforeEach(() => {
         cy.visitStory('components-modal--modal')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-modal').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-monitoring-icon/test/rux-monitoring-icon.e2e.js
+++ b/src/components/rux-monitoring-icon/test/rux-monitoring-icon.e2e.js
@@ -2,7 +2,7 @@ describe('Monitoring Icon', () => {
     beforeEach(() => {
         cy.visitStory('components-monitoring-icon--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-monitoring-icon').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-monitoring-progress-icon/test/rux-monitoring-progress-icon.e2e.js
+++ b/src/components/rux-monitoring-progress-icon/test/rux-monitoring-progress-icon.e2e.js
@@ -4,7 +4,7 @@ describe('Monitoring Progress Icon', () => {
             'components-monitoring-progress-icon--monitoring-progress-icon'
         )
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-monitoring-progress-icon').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-notification/test/rux-notification.e2e.js
+++ b/src/components/rux-notification/test/rux-notification.e2e.js
@@ -2,7 +2,7 @@ describe('Notification', () => {
     beforeEach(() => {
         cy.visitStory('components-notification--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-notification').should('have.class', 'hydrated')
     })
 

--- a/src/components/rux-pop-up-menu/test/rux-pop-up-menu.e2e.js
+++ b/src/components/rux-pop-up-menu/test/rux-pop-up-menu.e2e.js
@@ -2,7 +2,7 @@ describe('Pop Up Menu', () => {
     beforeEach(() => {
         cy.visitStory('components-pop-up-menu--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-pop-up-menu').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-progress/test/rux-progress.e2e.js
+++ b/src/components/rux-progress/test/rux-progress.e2e.js
@@ -2,7 +2,7 @@ describe('Progress', () => {
     beforeEach(() => {
         cy.visitStory('components-progress--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-progress').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-push-button/test/rux-push-button.e2e.js
+++ b/src/components/rux-push-button/test/rux-push-button.e2e.js
@@ -1,8 +1,8 @@
 describe('Push Button', () => {
     beforeEach(() => {
-        cy.visitStory('components-push-button--push-button-story')
+        cy.visitStory('components-push-button--push-button')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-push-button').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-radio/test/rux-radio.e2e.js
+++ b/src/components/rux-radio/test/rux-radio.e2e.js
@@ -1,8 +1,8 @@
 describe('Checkbox', () => {
     beforeEach(() => {
-        cy.visitStory('components-form-elements--checkboxes')
+        cy.visitStory('components-radio--default-story')
     })
-    it('renders', async () => {
-        cy.get('rux-checkbox').should('have.class', 'hydrated')
+    it('renders', () => {
+        cy.get('rux-radio').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-segmented-button/test/rux-segmented-button.e2e.js
+++ b/src/components/rux-segmented-button/test/rux-segmented-button.e2e.js
@@ -2,7 +2,7 @@ describe('Segmented Button', () => {
     beforeEach(() => {
         cy.visitStory('components-segmented-button--segmented-button')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-segmented-button').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-slider/test/rux-slider.e2e.js
+++ b/src/components/rux-slider/test/rux-slider.e2e.js
@@ -4,7 +4,7 @@ describe('rux-slider', () => {
     beforeEach(() => {
         cy.visitStory('components-slider--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-slider').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-status/test/rux-status.e2e.js
+++ b/src/components/rux-status/test/rux-status.e2e.js
@@ -2,7 +2,7 @@ describe('Status', () => {
     beforeEach(() => {
         cy.visitStory('components-status--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-status').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-switch/test/rux-switch.e2e.js
+++ b/src/components/rux-switch/test/rux-switch.e2e.js
@@ -2,7 +2,7 @@ describe('Switch', () => {
     beforeEach(() => {
         cy.visitStory('components-switch--switch-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-switch').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-textarea/test/rux-textarea.e2e.js
+++ b/src/components/rux-textarea/test/rux-textarea.e2e.js
@@ -2,7 +2,7 @@ describe('Textarea', () => {
     beforeEach(() => {
         cy.visitStory('components-textarea--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-textarea').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-tree-node/test/rux-tree-node.e2e.js
+++ b/src/components/rux-tree-node/test/rux-tree-node.e2e.js
@@ -2,7 +2,7 @@ describe('Tree Node', () => {
     beforeEach(() => {
         cy.visitStory('components-tree-node--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-tree-node').should('have.class', 'hydrated')
     })
 })

--- a/src/components/rux-tree/test/rux-tree.e2e.js
+++ b/src/components/rux-tree/test/rux-tree.e2e.js
@@ -2,7 +2,7 @@ describe('Tree', () => {
     beforeEach(() => {
         cy.visitStory('components-tree--default-story')
     })
-    it('renders', async () => {
+    it('renders', () => {
         cy.get('rux-tree').should('have.class', 'hydrated')
     })
 


### PR DESCRIPTION
## Brief Description

Using `async` in the Cypress test was causing them all to pass no matter what. 

## JIRA Link

[ASTRO-1704](https://rocketcom.atlassian.net/browse/ASTRO-1704)

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
