### PR TITLE
fix(rux-select): label font

### DIFF
--- a/src/components/rux-select/rux-select.scss
+++ b/src/components/rux-select/rux-select.scss
@@ -36,6 +36,7 @@
 }
 
 label {
+    font-family: var(--fontFamily);
     display: inline-block;
     margin-bottom: 10px;
     color: var(--selectMenuLabelColor);


### PR DESCRIPTION
## Brief Description

If you set a global font-family on the body or any parent element, it would change the font family on the select label.

## JIRA Link

[ASTRO-1757](https://rocketcom.atlassian.net/browse/ASTRO-1757)

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
