### PR TITLE
fix(core): fix custom-elements-bundle build

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,1 +1,0 @@
-declare module '*.md'


### PR DESCRIPTION
## Brief Description

Custom Elements build now correctly imports `import type { Components, JSX } from "../types/components";`

## JIRA Link

[ASTRO-1795](https://rocketcom.atlassian.net/browse/ASTRO-1795)

## Motivation and Context

Stencil output targets will not correctly build

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have added tests to cover my changes.
