### PR TITLE
ASTRO-1696 fouc fix

### DIFF
--- a/src/global/_fouc.scss
+++ b/src/global/_fouc.scss
@@ -1,0 +1,3 @@
+rux-menu-item:not(:defined) {
+    visibility: hidden;
+}

--- a/src/global/global.scss
+++ b/src/global/global.scss
@@ -1,4 +1,5 @@
 @forward './theme/theme-light';
 
 @use 'variables';
+@use 'fouc';
 @use 'reset';


### PR DESCRIPTION
## Brief Description

Currently while in draft PR, I am looking for feedback on if we think this is the solution we want to go with or if anyone has any recommendations. 

There is a [known bug](https://github.com/ionic-team/stencil/issues/2101) in stencil where components slot content will flash an unstyled render of their content before the component becomes hydrated. This is happening with our rux-pop-up and flashing the rux-menu-item content that is slotted. This fix adds a new global style sheet with one rule targeting the rux-menu-item and hiding it before it is defined. This is one of several possible solutions but seems to be the best at the time.

## JIRA Link

[ASTRO-1696](https://rocketcom.atlassian.net/browse/ASTRO-1696)

## General Notes

If you have trouble seeing the flash of content set your throttling to 3G in your network tab. 

## Issues and Limitations

Whatever solution we go with we will need to update documentation to point this out to developers in case it produces issues with framework integration.

## Types of changes

-   [X] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [X] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
