### PR TITLE
Fax 1689 pop up testing

### DIFF
--- a/src/components/rux-menu-item/rux-menu-item.tsx
+++ b/src/components/rux-menu-item/rux-menu-item.tsx
@@ -60,7 +60,11 @@ export class RuxMenuItem {
     /**
      * Emitted when item is clicked. Ex `{value : 10}`
      */
-    @Event({ eventName: 'rux-menu-item-selected' })
+    @Event({
+        eventName: 'rux-menu-item-selected',
+        bubbles: true,
+        composed: true,
+    })
     ruxMenuItemSelected!: EventEmitter<object>
     private itemOnClick = () => {
         const emittedValue = this.value ? this.value : this.el.textContent

--- a/src/components/rux-menu-item/rux-menu-item.tsx
+++ b/src/components/rux-menu-item/rux-menu-item.tsx
@@ -6,6 +6,7 @@ import {
     Prop,
     EventEmitter,
     Event,
+    Listen,
 } from '@stencil/core'
 
 /**
@@ -66,33 +67,28 @@ export class RuxMenuItem {
         composed: true,
     })
     ruxMenuItemSelected!: EventEmitter<object>
+
+    @Listen('click')
+    handleClick() {
+        if (!this.disabled) {
+            this.itemOnClick()
+        }
+    }
+
     private itemOnClick = () => {
         const emittedValue = this.value ? this.value : this.el.textContent
         this.ruxMenuItemSelected.emit({ value: emittedValue })
     }
 
-    private isClickable(): boolean {
-        return !this.disabled
-    }
-
     render() {
-        const { disabled, href, rel, download, target, itemOnClick } = this
-        const clickable = this.isClickable()
+        const { disabled, href, rel, download, target } = this
         const TagType = href ? 'a' : 'div'
         const attributes =
             TagType === 'a' ? { download, href, rel, target } : {}
-        // Only sets onClick if the item is clickable for screen readers
-        const clickFunc = clickable
-            ? {
-                  onClick: () => {
-                      itemOnClick()
-                  },
-              }
-            : {}
 
         return (
             <Host aria-disabled={disabled ? 'true' : null}>
-                <li {...clickFunc}>
+                <li>
                     <TagType {...attributes}>
                         <slot name="start"></slot>
                         <slot></slot>

--- a/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -9,6 +9,7 @@ import {
     Method,
     Watch,
     State,
+    Listen,
 } from '@stencil/core'
 
 /**
@@ -133,11 +134,12 @@ export class RuxPopUpMenu {
     @Method()
     async toggle(): Promise<boolean> {
         this.open = !this.open
-        if (this.open) {
-            return true
-        } else {
-            return false
-        }
+        return this.open
+    }
+
+    @Listen('rux-menu-item-selected')
+    handleListen(e: CustomEvent) {
+        this.open = false
     }
 
     private _bindElements() {

--- a/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
+++ b/src/components/rux-pop-up-menu/rux-pop-up-menu.tsx
@@ -138,7 +138,7 @@ export class RuxPopUpMenu {
     }
 
     @Listen('rux-menu-item-selected')
-    handleListen(e: CustomEvent) {
+    handleListen() {
         this.open = false
     }
 

--- a/src/components/rux-pop-up-menu/test/rux-pop-up-menu.e2e.js
+++ b/src/components/rux-pop-up-menu/test/rux-pop-up-menu.e2e.js
@@ -1,8 +1,74 @@
+const { el } = require('date-fns/locale')
+
 describe('Pop Up Menu', () => {
+    const menuRef = 'rux-pop-up-menu'
+
     beforeEach(() => {
         cy.visitStory('components-pop-up-menu--default-story')
     })
+
     it('renders', () => {
         cy.get('rux-pop-up-menu').should('have.class', 'hydrated')
+    })
+})
+
+describe('Pop Up Menu Item', () => {
+    beforeEach(() => {
+        cy.visitForm('pop-up-menu')
+    })
+
+    it('should open and close popup by togglying open attribute', () => {
+        cy.get('rux-button').shadow().find('button').click({ force: true })
+
+        cy.get('rux-pop-up-menu').should('have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'false')
+
+        cy.get('rux-pop-up-menu').then(($popUp) => {
+            $popUp[0].removeAttribute('open')
+        })
+
+        cy.get('rux-pop-up-menu').should('not.have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'true')
+    })
+
+    it('should open clicking on anchor element', () => {
+        cy.get('rux-button').shadow().find('button').click({ force: true })
+        cy.get('rux-pop-up-menu').should('have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'false')
+    })
+
+    it('should close clicking outside of the popup element', () => {
+        cy.get('rux-button').shadow().find('button').click({ force: true })
+
+        cy.get('rux-pop-up-menu').should('have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'false')
+
+        cy.get('body').click()
+
+        cy.get('rux-pop-up-menu').should('not.have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'true')
+    })
+
+    it('should select item and closes menu', () => {
+        cy.get('rux-button').shadow().find('button').click({ force: true })
+        cy.wait(50)
+        cy.get('rux-pop-up-menu rux-menu-item:nth-child(1)').click()
+
+        cy.get('rux-pop-up-menu').should('not.have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'true')
+
+        cy.get('#log').contains('Value:Item 1')
+    })
+
+    it('should open menu add another item and close', () => {
+        cy.get('rux-button').shadow().find('button').click({ force: true })
+        cy.get('rux-pop-up-menu').should('have.attr', 'open')
+        cy.get('rux-pop-up-menu').should('have.attr', 'aria-hidden', 'false')
+
+        cy.get('rux-pop-up-menu rux-menu-item:nth-child(5)').click({
+            force: true,
+        })
+
+        cy.get('#log').contains('Value:Item 4')
     })
 })

--- a/src/tests/pages/form-pop-up-menu.html
+++ b/src/tests/pages/form-pop-up-menu.html
@@ -35,10 +35,10 @@
                 "
             >
                 <div>
-                    <rux-button aria-controls="popup-menu-1"
-                        >Open Menu</rux-button
-                    >
-                    <!-- <rux-icon icon="apps" aria-controls="popup-menu-1" style="display: inline-block; min-width: 19px;"></rux-icon> -->
+                    <rux-button aria-controls="popup-menu-1">
+                        Open Menu
+                    </rux-button>
+
                     <rux-pop-up-menu id="popup-menu-1">
                         <rux-menu-item>Item 1</rux-menu-item>
                         <rux-menu-item-divider></rux-menu-item-divider>
@@ -66,15 +66,10 @@
                 const menu = document.querySelectorAll('rux-menu-item')
 
                 menu.forEach((item) => {
-                    item.addEventListener(
-                        'rux-menu-item-selected',
-                        function (e) {
-                            const item = document.createElement('li')
-                            console.log('e', e)
-                            item.innerHTML = `<strong>Value:</strong>${e.detail.value}`
-                            log.appendChild(item)
-                        }
-                    )
+                    item.addEventListener('rux-menu-item-selected', (e) => {
+                        item.innerHTML = `<strong>Value:</strong>${e.detail.value}`
+                        log.appendChild(item)
+                    })
                 })
             </script>
         </div>

--- a/src/tests/pages/form-pop-up-menu.html
+++ b/src/tests/pages/form-pop-up-menu.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+        />
+        <title>Stencil Component Starter</title>
+
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400&family=Roboto:wght@100;300;400;500;700;900&display=swap"
+            rel="stylesheet"
+        />
+        <script
+            type="module"
+            src="/dist/astro-web-components/astro-web-components.esm.js"
+        ></script>
+        <script nomodule src="/dist/esm/astro-web-components.js"></script>
+
+        <link
+            rel="stylesheet"
+            href="/dist/astro-web-components/astro-web-components.css"
+        />
+    </head>
+
+    <body class="dark-theme">
+        <div style="padding: 10%; display: flex; justify-content: center">
+            <section
+                style="
+                    width: 600px;
+                    display: flex;
+                    justify-content: space-between;
+                "
+            >
+                <div>
+                    <rux-button aria-controls="popup-menu-1"
+                        >Open Menu</rux-button
+                    >
+                    <!-- <rux-icon icon="apps" aria-controls="popup-menu-1" style="display: inline-block; min-width: 19px;"></rux-icon> -->
+                    <rux-pop-up-menu id="popup-menu-1">
+                        <rux-menu-item>Item 1</rux-menu-item>
+                        <rux-menu-item-divider></rux-menu-item-divider>
+                        <rux-menu-item value="2"
+                            >Item 2 with an exceedingly long title that overruns
+                            the width</rux-menu-item
+                        >
+                        <rux-menu-item disabled
+                            >Item 3 is disabled</rux-menu-item
+                        >
+                        <rux-menu-item value="Item 4"
+                            >Item 4 has a string value</rux-menu-item
+                        >
+                        <rux-menu-item href="https://www.astrouxds.com"
+                            >Item 5 is an anchor</rux-menu-item
+                        >
+                    </rux-pop-up-menu>
+                </div>
+                <div>
+                    <ul id="log"></ul>
+                </div>
+            </section>
+            <script>
+                const log = document.getElementById('log')
+                const menu = document.querySelectorAll('rux-menu-item')
+
+                menu.forEach((item) => {
+                    item.addEventListener(
+                        'rux-menu-item-selected',
+                        function (e) {
+                            const item = document.createElement('li')
+                            console.log('e', e)
+                            item.innerHTML = `<strong>Value:</strong>${e.detail.value}`
+                            log.appendChild(item)
+                        }
+                    )
+                })
+            </script>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
## Brief Description

fixes for rux-menu-item and rux-popup-menu components

added event listener to the menu to close it when item was selected
removed React style click hook from rux-menu-item in favor of stencil @listen click handler

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1689

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

Follow on spy events for stencil story testing
https://rocketcom.atlassian.net/browse/ASTRO-1812

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have added tests to cover my changes.
