### PR TITLE
docs(rux-button-group): rename outline -> secondary

### DIFF
--- a/src/components/rux-button-group/readme.md
+++ b/src/components/rux-button-group/readme.md
@@ -36,6 +36,13 @@ By default button group aligns buttons to the left. Alternatively an `h-align` p
 | `hAlign` | `h-align` | The horizontal alignment of buttons within the group | `"center" \| "left" \| "right"` | `'left'` |
 
 
+## Slots
+
+| Slot          | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `"(default)"` | Two or more RuxButton components to render in the group |
+
+
 ## Dependencies
 
 ### Used by

--- a/src/components/rux-button-group/rux-button-group.tsx
+++ b/src/components/rux-button-group/rux-button-group.tsx
@@ -1,5 +1,8 @@
 import { Prop, Component, h } from '@stencil/core'
 
+/**
+ * @slot (default) - Two or more RuxButton components to render in the group
+ */
 @Component({
     tag: 'rux-button-group',
     styleUrl: 'rux-button-group.scss',

--- a/src/stories/button-group.stories.mdx
+++ b/src/stories/button-group.stories.mdx
@@ -43,7 +43,7 @@ export const Default = (args) => {
         <div style="padding: 10%; display: flex; justify-content: center;">
             <div class="example-container">
                 <rux-button-group .hAlign="${args.hAlign ? args.hAlign : 'right'}">
-                    <rux-button outline>Cancel</rux-button>
+                    <rux-button secondary>Cancel</rux-button>
                     <rux-button>Continue</rux-button>
                 </rux-button-group>
             </div>


### PR DESCRIPTION
## Brief Description

Fixes secondary button in example

## JIRA Link

[ASTRO-1762](https://rocketcom.atlassian.net/browse/ASTRO-1762)

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
