### PR TITLE
docs(rux-clock): add small variant; use rux-table

### DIFF
--- a/src/stories/clock.stories.mdx
+++ b/src/stories/clock.stories.mdx
@@ -77,37 +77,173 @@ export const ClockWithAosLos = (args) => {
     </Story>
 </Canvas>
 
+### Small
+export const Small = (args) => {
+    return html`
+        <div style="padding: 10%; display: flex; justify-content: center;">
+            <rux-clock
+                .timezone="${args.timezone}"
+                .aos="${args.aos}"
+                .los="${args.los}"
+                ?hide-timezone="${args.hideTimezone}"
+                ?hide-date="${args.hideDate}"
+                ?small="${args.small}"
+            ></rux-clock>
+        </div>
+    `
+}
+
+<Canvas>
+    <Story
+        args={{
+          small: true
+        }}
+        name="Small"
+    >
+        {Small.bind()}
+    </Story>
+</Canvas>
+
 ## Military Timezones
 
 Clock's timezone parameter can accept any military timezone.
 
-|Time zone name|Prop Letter|Offset|
-|--- |--- |--- |
-|Alpha Time Zone|A|+1|
-|Bravo Time Zone|B|+2|
-|Charlie Time Zone|C|+3|
-|Delta Time Zone|D|+4|
-|Echo Time Zone|E|+5|
-|Foxtrot Time Zone|F|+6|
-|Golf Time Zone|G|+7|
-|Hotel Time Zone|H|+8|
-|India Time Zone|I|+9|
-|Kilo Time Zone|K|+10|
-|Lima Time Zone|L|+11|
-|Mike Time Zone|M|+12|
-|November Time Zone|N|−1|
-|Oscar Time Zone|O|−2|
-|Papa Time Zone|P|−3|
-|Quebec Time Zone|Q|−4|
-|Romeo Time Zone|R|−5|
-|Sierra Time Zone|S|−6|
-|Tango Time Zone|T|−7|
-|Uniform Time Zone|U|−8|
-|Victor Time Zone|V|−9|
-|Whiskey Time Zone|W|−10|
-|X-ray Time Zone|X|−11|
-|Yankee Time Zone|Y|−12|
-|Zulu Time Zone|Z|0|
+<rux-table>
+    <rux-table-header>
+        <rux-table-header-row>
+            <rux-table-header-cell>Timezone Name</rux-table-header-cell>
+            <rux-table-header-cell>Prop Letter</rux-table-header-cell>
+            <rux-table-header-cell>Offset</rux-table-header-cell>
+        </rux-table-header-row>
+    </rux-table-header>
+    <rux-table-body>
+      <rux-table-row>
+        <rux-table-cell>Alpha Time Zone</rux-table-cell>
+        <rux-table-cell>A</rux-table-cell>
+        <rux-table-cell>+1</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Bravo Time Zone</rux-table-cell>
+        <rux-table-cell>B</rux-table-cell>
+        <rux-table-cell>+2</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Charlie Time Zone</rux-table-cell>
+        <rux-table-cell>C</rux-table-cell>
+        <rux-table-cell>+3</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Delta Time Zone</rux-table-cell>
+        <rux-table-cell>D</rux-table-cell>
+        <rux-table-cell>+4</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Echo Time Zone</rux-table-cell>
+        <rux-table-cell>E</rux-table-cell>
+        <rux-table-cell>+5</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Foxtrot Time Zone</rux-table-cell>
+        <rux-table-cell>F</rux-table-cell>
+        <rux-table-cell>+6</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Golf Time Zone</rux-table-cell>
+        <rux-table-cell>G</rux-table-cell>
+        <rux-table-cell>+7</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Hotel Time Zone</rux-table-cell>
+        <rux-table-cell>H</rux-table-cell>
+        <rux-table-cell>+8</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>India Time Zone</rux-table-cell>
+        <rux-table-cell>I</rux-table-cell>
+        <rux-table-cell>+9</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Kilo Time Zone</rux-table-cell>
+        <rux-table-cell>K</rux-table-cell>
+        <rux-table-cell>+10</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Lima Time Zone</rux-table-cell>
+        <rux-table-cell>L</rux-table-cell>
+        <rux-table-cell>+11</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Mike Time Zone</rux-table-cell>
+        <rux-table-cell>M</rux-table-cell>
+        <rux-table-cell>+12</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>November Time Zone</rux-table-cell>
+        <rux-table-cell>N</rux-table-cell>
+        <rux-table-cell>−1</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Oscar Time Zone</rux-table-cell>
+        <rux-table-cell>O</rux-table-cell>
+        <rux-table-cell>−2</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Papa Time Zone</rux-table-cell>
+        <rux-table-cell>P</rux-table-cell>
+        <rux-table-cell>−3</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Quebec Time Zone</rux-table-cell>
+        <rux-table-cell>Q</rux-table-cell>
+        <rux-table-cell>−4</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Romeo Time Zone</rux-table-cell>
+        <rux-table-cell>R</rux-table-cell>
+        <rux-table-cell>−5</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Sierra Time Zone</rux-table-cell>
+        <rux-table-cell>S</rux-table-cell>
+        <rux-table-cell>−6</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Tango Time Zone</rux-table-cell>
+        <rux-table-cell>T</rux-table-cell>
+        <rux-table-cell>−7</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Uniform Time Zone</rux-table-cell>
+        <rux-table-cell>U</rux-table-cell>
+        <rux-table-cell>−8</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Victor Time Zone</rux-table-cell>
+        <rux-table-cell>V</rux-table-cell>
+        <rux-table-cell>−9</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Whiskey Time Zone</rux-table-cell>
+        <rux-table-cell>W</rux-table-cell>
+        <rux-table-cell>−10</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>X-ray Time</rux-table-cell>
+        <rux-table-cell>o</rux-table-cell>
+        <rux-table-cell>e</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Yankee Time Zone</rux-table-cell>
+        <rux-table-cell>Y</rux-table-cell>
+        <rux-table-cell>−12</rux-table-cell>
+      </rux-table-row>
+      <rux-table-row>
+        <rux-table-cell>Zulu Time Zone</rux-table-cell>
+        <rux-table-cell>Z</rux-table-cell>
+        <rux-table-cell>0</rux-table-cell>
+      </rux-table-row>
+    </rux-table-body>
+</rux-table>
 
 ## Cherry Picking
 


### PR DESCRIPTION
## Brief Description

Adds small variant
Replaces markdown table with Rux Table - I think it looks nicer

## JIRA Link

[ASTRO-1765](https://rocketcom.atlassian.net/browse/ASTRO-1765)

## Types of changes

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
