### PR TITLE
Bug(rux-checkbox): Indeterminate functionality - Astro 1736

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "start.storybook": "start-storybook -p 6006 -s ./dist",
         "start": "concurrently npm:start.stencil npm:start.storybook",
         "test.e2e.run": "concurrently --success=first \"http-server -p 4444 .\" \"cypress run\"",
-        "test.e2e.watch": "concurrently --sucess=first \"http-server -p 4444 .\" \"cypress open\"",
+        "test.e2e.watch": "concurrently --success=first \"http-server -p 4444 .\" \"cypress open\"",
         "test.e2e": "npm run build && npm run test.e2e.run",
         "test.unit.watch": "TZ=UTC stencil test --spec --watchAll",
         "test.unit": "TZ=UTC stencil test --spec --coverage",

--- a/src/components/rux-checkbox/rux-checkbox.scss
+++ b/src/components/rux-checkbox/rux-checkbox.scss
@@ -97,6 +97,21 @@
             }
         }
 
+        &:indeterminate + label::after {
+            position: absolute;
+            display: flex;
+            content: '';
+
+            top: 5px;
+            width: 10px !important;
+            height: 5px !important;
+            transform: rotate(0deg) !important;
+            border-right: 0px !important;
+            border-top: 0px !important;
+            border-bottom: 2px solid var(--controlTextColor) !important;
+            left: 4px !important;
+        }
+
         &:disabled {
             + label {
                 cursor: var(--disabledCursor);
@@ -111,16 +126,6 @@
                 border-color: var(--controlHoverBorderColor);
             }
         }
-    }
-
-    input[indeterminate]:checked + label::after {
-        width: 10px !important;
-        height: 5px !important;
-        transform: rotate(0deg) !important;
-        border-right: 0px !important;
-        border-top: 0px !important;
-        border-bottom: 2px solid var(--controlTextColor) !important;
-        left: 4px !important;
     }
 
     &--has-error {

--- a/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/src/components/rux-checkbox/rux-checkbox.tsx
@@ -39,7 +39,7 @@ export class RuxCheckbox {
     /**
      * Toggles indeterminate state of a checkbox
      */
-    @Prop({ reflect: true }) indeterminate: boolean = false
+    @Prop({ reflect: true, mutable: true }) indeterminate: boolean = false
 
     /**
      * Disables the checkbox via HTML disabled attribute. Checkbox takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
@@ -79,16 +79,19 @@ export class RuxCheckbox {
 
         if (input && this.indeterminate) {
             // indeterminate property does not exist in HTML but is accessible via js
-            input.setAttribute(
-                'indeterminate',
-                this.indeterminate ? 'indeterminate' : ''
-            )
+            input.indeterminate = true
         }
     }
 
     private _onChange(e: Event): void {
         const target = e.target as HTMLInputElement
-        this.checked = target.checked
+        if (!this.indeterminate) {
+            this.checked = target.checked
+        } else {
+            target.checked = true
+            this.checked = true
+            this.indeterminate = false
+        }
         this.ruxChange.emit(this.checked)
     }
 

--- a/src/components/rux-checkbox/rux-checkbox.tsx
+++ b/src/components/rux-checkbox/rux-checkbox.tsx
@@ -1,4 +1,12 @@
-import { Component, h, Prop, Event, EventEmitter, Element } from '@stencil/core'
+import {
+    Component,
+    h,
+    Prop,
+    Event,
+    EventEmitter,
+    Element,
+    Watch,
+} from '@stencil/core'
 import { renderHiddenInput } from '../../utils/utils'
 
 let id = 0
@@ -41,6 +49,11 @@ export class RuxCheckbox {
      */
     @Prop({ reflect: true, mutable: true }) indeterminate: boolean = false
 
+    @Watch('indeterminate')
+    resetChecked() {
+        this.checked = false
+    }
+
     /**
      * Disables the checkbox via HTML disabled attribute. Checkbox takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
      */
@@ -80,18 +93,16 @@ export class RuxCheckbox {
         if (input && this.indeterminate) {
             // indeterminate property does not exist in HTML but is accessible via js
             input.indeterminate = true
+            this.checked = false
         }
     }
 
     private _onChange(e: Event): void {
         const target = e.target as HTMLInputElement
-        if (!this.indeterminate) {
-            this.checked = target.checked
-        } else {
-            target.checked = true
-            this.checked = true
+        if (this.indeterminate) {
             this.indeterminate = false
         }
+        this.checked = target.checked
         this.ruxChange.emit(this.checked)
     }
 

--- a/src/components/rux-checkbox/test/form-checkbox.e2e.js
+++ b/src/components/rux-checkbox/test/form-checkbox.e2e.js
@@ -56,4 +56,21 @@ describe('Checkbox with Form', () => {
         cy.get('#form').submit()
         cy.get('#log').should('not.contain', 'ruxCheckbox')
     })
+
+    it('does not submit any value if indeterminate', () => {
+        cy.get('#ruxCheckbox')
+            .invoke('prop', 'checked', 'true')
+            .should('have.attr', 'checked', 'checked')
+            .invoke('prop', 'indeterminate', 'true')
+            .should('not.have.attr', 'checked')
+        cy.get('#log').should('not.contain', 'ruxCheckbox')
+    })
+
+    it('should be checked when clicking an indeterminate checkbox', () => {
+        cy.get('#ruxCheckbox').invoke('prop', 'indeterminate', 'true')
+        cy.get('#ruxCheckbox').shadow().find('input').click({ force: true })
+        cy.get('#ruxCheckbox')
+            .should('have.attr', 'checked', 'checked')
+            .should('not.have.attr', 'indeterminate')
+    })
 })


### PR DESCRIPTION
## Brief Description

Indeterminate functionality was not fully fleshed out within component. This PR addresses the indeterminate state
<!--- Describe your changes in detail -->

## JIRA Link

[Astro 1736](https://rocketcom.atlassian.net/browse/ASTRO-1736?atlOrigin=eyJpIjoiMDhlODM5MmE0YjNlNGU1NmIzMDhjNGFiNzM3YjllNzAiLCJwIjoiaiJ9)
<!--- Please add JIRA ticket link here. -->

## Related Issue

## General Notes

## Motivation and Context

Indeterminate behavior was not the standard behavior. Previously indeterminate prop had to be true and checked had to be true. That also meant that when using forms the checkbox would submit a value as checked was true. Now if indeterminate state is true checked reverts to false as to not submit anything. 

When clicking an indeterminate checkbox it will set the indeterminate state to false and the checked state to true.
<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have added tests to cover my changes.
