### PR TITLE
Astro 1784 tabs audit

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -40760,6 +40760,10 @@ declare namespace LocalJSX {
     }
     interface RuxTabs {
         /**
+          * Fires whenever a new tab is selected, and emits the selected tab.
+         */
+        "onRux-selected"?: (event: CustomEvent<any>) => void;
+        /**
           * If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses.
          */
         "small"?: boolean;

--- a/src/components/rux-notification/readme.md
+++ b/src/components/rux-notification/readme.md
@@ -78,6 +78,13 @@ The Astro UXDS Notification Banner hides from view using absolute positioning in
 | `status`     | `status`      | The background color. Possible values include 'standby', 'normal', 'caution', and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).                                                                                                                                                                                                                                                                                                                     | `"caution" \| "critical" \| "normal" \| "standby"` | `'standby'` |
 
 
+## CSS Custom Properties
+
+| Name                      | Description                 |
+| ------------------------- | --------------------------- |
+| `--notificationTextColor` | The notification text color |
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/components/rux-push-button/readme.md
+++ b/src/components/rux-push-button/readme.md
@@ -128,14 +128,14 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 
 ## CSS Custom Properties
 
-| Name                                 | Description                                   |
-| ------------------------------------ | --------------------------------------------- |
-| `--pushbuttonBackgroundColor`        | the Push Button background color              |
-| `--pushbuttonBorderColor`            | the Push Button border color                  |
-| `--pushbuttonSelectdBackgroundColor` | the Push Button background color when checked |
-| `--pushbuttonSelectedBorderColor`    | the Push Button border color when checked     |
-| `--pushbuttonSelectedTextColor`      | the Push Button text color when checked       |
-| `--pushbuttonTextColor`              | the Push Button text color                    |
+| Name                                  | Description                                   |
+| ------------------------------------- | --------------------------------------------- |
+| `--pushbuttonBackgroundColor`         | the Push Button background color              |
+| `--pushbuttonBorderColor`             | the Push Button border color                  |
+| `--pushbuttonSelectedBackgroundColor` | the Push Button background color when checked |
+| `--pushbuttonSelectedBorderColor`     | the Push Button border color when checked     |
+| `--pushbuttonSelectedTextColor`       | the Push Button text color when checked       |
+| `--pushbuttonTextColor`               | the Push Button text color                    |
 
 
 ----------------------------------------------

--- a/src/components/rux-tabs/readme.md
+++ b/src/components/rux-tabs/readme.md
@@ -108,6 +108,13 @@ Astro UXDS Tab (child) properties are passed as simple attributes on the individ
 | `small`  | `small`   | If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses. | `boolean \| undefined` | `undefined` |
 
 
+## Slots
+
+| Slot          | Description                   |
+| ------------- | ----------------------------- |
+| `"(default)"` | Used for instances of rux-tab |
+
+
 ## CSS Custom Properties
 
 | Name               | Description      |

--- a/src/components/rux-tabs/readme.md
+++ b/src/components/rux-tabs/readme.md
@@ -108,6 +108,13 @@ Astro UXDS Tab (child) properties are passed as simple attributes on the individ
 | `small`  | `small`   | If passed or set to true, displays the tabs in a smaller style, suitable for limited-space uses. | `boolean \| undefined` | `undefined` |
 
 
+## Events
+
+| Event          | Description                                                       | Type               |
+| -------------- | ----------------------------------------------------------------- | ------------------ |
+| `rux-selected` | Fires whenever a new tab is selected, and emits the selected tab. | `CustomEvent<any>` |
+
+
 ## Slots
 
 | Slot          | Description                   |

--- a/src/components/rux-tabs/rux-tab-panel/readme.md
+++ b/src/components/rux-tabs/rux-tab-panel/readme.md
@@ -3,6 +3,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `"(default)"` | Used to render any additional content inside a rux-tab-panel. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/rux-tabs/rux-tab-panel/rux-tab-panel.tsx
+++ b/src/components/rux-tabs/rux-tab-panel/rux-tab-panel.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Element } from '@stencil/core'
 
+/**
+ * @slot (default) - Used to render any additional content inside a rux-tab-panel.
+ */
 @Component({
     tag: 'rux-tab-panel',
     styleUrl: 'rux-tab-panel.scss',

--- a/src/components/rux-tabs/rux-tab-panels/readme.md
+++ b/src/components/rux-tabs/rux-tab-panels/readme.md
@@ -10,6 +10,13 @@
 | `rux-register-panels` | Emits a list of the Tab Panels that have been passed in | `CustomEvent<HTMLRuxTabPanelsElement[]>` |
 
 
+## Slots
+
+| Slot          | Description                         |
+| ------------- | ----------------------------------- |
+| `"(default)"` | Used for instances of rux-tab-panel |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
+++ b/src/components/rux-tabs/rux-tab-panels/rux-tab-panels.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Element, Event, EventEmitter } from '@stencil/core'
 
+/**
+ * @slot (default) - Used for instances of rux-tab-panel
+ */
 @Component({
     tag: 'rux-tab-panels',
     styleUrl: '.././rux-tab-panel/rux-tab-panel.scss',

--- a/src/components/rux-tabs/rux-tabs.tsx
+++ b/src/components/rux-tabs/rux-tabs.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, State, Prop, Element, Listen } from '@stencil/core'
 
+/**
+ * @slot (default) - Used for instances of rux-tab
+ */
 @Component({
     tag: 'rux-tabs',
     styleUrl: 'rux-tabs.scss',

--- a/src/components/rux-tabs/rux-tabs.tsx
+++ b/src/components/rux-tabs/rux-tabs.tsx
@@ -1,4 +1,14 @@
-import { Component, Host, h, State, Prop, Element, Listen } from '@stencil/core'
+import {
+    Component,
+    Host,
+    h,
+    State,
+    Prop,
+    Element,
+    Listen,
+    Event,
+    EventEmitter,
+} from '@stencil/core'
 
 /**
  * @slot (default) - Used for instances of rux-tab
@@ -29,8 +39,12 @@ export class RuxTabs {
         this._registerPanels(e)
     }
 
+    /**
+     * Fires whenever a new tab is selected, and emits the selected tab.
+     */
+    @Event({ eventName: 'rux-selected' }) ruxSelected!: EventEmitter
+
     connectedCallback() {
-        this.el.addEventListener('click', (e) => this._onClick(e))
         this._addTabs()
     }
 
@@ -50,6 +64,7 @@ export class RuxTabs {
 
     _onClick(e: MouseEvent) {
         const tab = e.target as HTMLRuxTabElement
+        this.ruxSelected.emit(tab)
         if (
             tab.getAttribute('role') === 'tab' &&
             tab.getAttribute('disabled') === null
@@ -81,7 +96,7 @@ export class RuxTabs {
 
     render() {
         return (
-            <Host>
+            <Host onClick={(e: MouseEvent) => this._onClick(e)}>
                 <slot></slot>
             </Host>
         )

--- a/src/stories/tab.stories.mdx
+++ b/src/stories/tab.stories.mdx
@@ -29,9 +29,51 @@ export const Default = (args) => {
     </Story>
 </Canvas>
 
+
+
 ## API
 
 <ArgsTable of="rux-tab" />
+
+## Variants
+
+### Disabled
+export const Disabled = (args) => {
+  return html`
+    <rux-tab id="tab1" .disabled=${args.disabled} .selected=${args.selected}>Tab 1</rux-tab>
+  `
+}
+
+<Canvas>
+    <Story
+      name="Disabled"
+      args={{
+        disabled: true
+      }}
+    >
+    {Disabled.bind()}
+    </Story>
+</Canvas>
+
+
+
+### Selected
+export const Selected = (args) => {
+  return html`
+    <rux-tab id="tab1" .disabled=${args.disabled} .selected=${args.selected}>Tab 1</rux-tab>
+  `
+}
+
+<Canvas>
+    <Story
+      name="Selected"
+      args={{
+        selected: true
+      }}
+    >
+    {Selected.bind()}
+    </Story>
+</Canvas>
 
 ## Cherry Picking
 

--- a/src/stories/tabs.stories.mdx
+++ b/src/stories/tabs.stories.mdx
@@ -10,6 +10,11 @@ import { html, render } from 'lit-html'
       'RuxTabPanels': 'rux-tab-panels'
       }}
     argTypes={extractArgTypes('rux-tabs')}
+    parameters={{
+        actions: {
+            handles: ['rux-selected rux-tabs']
+        }
+    }}
 />
 
 # Tabs


### PR DESCRIPTION
## Brief Description

Audit for the rux-tabs and rux-tab components on storybook. Added some @slot declarations and variants for rux-tab.
Added rux-selected event when a new tab is clicked that emits the selected tab.

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1785 --> tabs
https://rocketcom.atlassian.net/browse/ASTRO-1784 --> tab

## Related Issue

## General Notes

There is one event on rux-tab-panles tsx that fires on component load. I couldn't get it to show up in the actions tab, most likely because it's on component load.

## Motivation and Context

Audit for storybook-next

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
