### PR TITLE
Astro 1780 select audit

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16349,7 +16349,7 @@ export namespace Components {
     }
     interface RuxSelect {
         /**
-          * Disables the item
+          * Disables the select menu via HTML disabled attribute. Select menu takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
          */
         "disabled": boolean;
         /**
@@ -40612,7 +40612,7 @@ declare namespace LocalJSX {
     }
     interface RuxSelect {
         /**
-          * Disables the item
+          * Disables the select menu via HTML disabled attribute. Select menu takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
          */
         "disabled"?: boolean;
         /**

--- a/src/components/rux-select/rux-select.scss
+++ b/src/components/rux-select/rux-select.scss
@@ -81,6 +81,9 @@ label {
     &:disabled {
         opacity: 0.4;
         cursor: not-allowed;
+        &:hover {
+            border: 1px solid var(--selectMenuBorderColor);
+        }
     }
 
     &.rux-select-invalid {

--- a/src/components/rux-select/rux-select.tsx
+++ b/src/components/rux-select/rux-select.tsx
@@ -66,7 +66,7 @@ export class RuxSelect {
             invalid,
             name,
         } = this
-        console.log('input id', this.inputId)
+
         return (
             <Host>
                 {label && (

--- a/src/components/rux-select/rux-select.tsx
+++ b/src/components/rux-select/rux-select.tsx
@@ -24,8 +24,7 @@ export class RuxSelect {
     /**
      * Id for the Select Input
      */
-    @Prop({ attribute: 'input-id' })
-    inputId?: string
+    @Prop({ attribute: 'input-id' }) inputId?: string
 
     /**
      * Id for the Label
@@ -67,7 +66,7 @@ export class RuxSelect {
             invalid,
             name,
         } = this
-
+        console.log('input id', this.inputId)
         return (
             <Host>
                 {label && (

--- a/src/components/rux-select/rux-select.tsx
+++ b/src/components/rux-select/rux-select.tsx
@@ -7,7 +7,7 @@ import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core'
 })
 export class RuxSelect {
     /**
-     * Disables the item
+     * Disables the select menu via HTML disabled attribute. Select menu takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored.
      */
     @Prop({ reflect: true }) disabled: boolean = false
 

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -67,6 +67,92 @@ export const SelectMenu = (args) => {
 ## API
 <ArgsTable of="rux-select" />
 
+## Variants
+
+### Disabled
+export const Disabled = (args) => {
+    return html`
+        <div style="width: 200px; margin: 0 auto;">
+            <rux-select
+                ?disabled="${args.disabled}"
+                ?required="${args.required}"
+                ?invalid="${args.invalid}"
+                label="${args.label}"
+                input-id="${args.inputId}"
+                label-id="${args.labelId}"
+            >
+                <option value="" selected>Select an option</option>
+                <optgroup label="Group one">
+                    <option value="1.1">Option 1.1</option>
+                    <option value="1.2">Option 1.2</option>
+                    <option value="1.3">Option 1.3</option>
+                    <option value="1.4">Option 1.4</option>
+                </optgroup>
+                <optgroup label="Group two">
+                    <option value="2.1">Option 2.1</option>
+                    <option value="2.2">Option 2.2</option>
+                    <option value="2.3">Option 2.3</option>
+                    <option value="2.4">Option 2.4</option>
+                </optgroup>
+            </rux-select>
+        </div>
+    `
+}
+
+<Canvas>
+    <Story
+        args={{
+            label: "Disabled Select Menu",
+            disabled: true
+        }}
+        name="Disabled"
+    >
+        {Disabled.bind()}
+    </Story>
+</Canvas>
+
+### Invalid
+export const Invalid = (args) => {
+    return html`
+        <div style="width: 200px; margin: 0 auto;">
+            <rux-select
+                ?disabled="${args.disabled}"
+                ?required="${args.required}"
+                ?invalid="${args.invalid}"
+                label="${args.label}"
+                input-id="${args.inputId}"
+                label-id="${args.labelId}"
+            >
+                <option value="" selected>Select an option</option>
+                <optgroup label="Group one">
+                    <option value="1.1">Option 1.1</option>
+                    <option value="1.2">Option 1.2</option>
+                    <option value="1.3">Option 1.3</option>
+                    <option value="1.4">Option 1.4</option>
+                </optgroup>
+                <optgroup label="Group two">
+                    <option value="2.1">Option 2.1</option>
+                    <option value="2.2">Option 2.2</option>
+                    <option value="2.3">Option 2.3</option>
+                    <option value="2.4">Option 2.4</option>
+                </optgroup>
+            </rux-select>
+        </div>
+    `
+}
+
+<Canvas>
+    <Story
+        args={{
+            label: "Invalid Select Menu",
+            invalid: true
+        }}
+        name="Invalid"
+    >
+        {Invalid.bind()}
+    </Story>
+</Canvas>
+
 ## Cherry Picking
 
 If you're already utilizing a build system that supports tree shaking and want to only import this individual component:

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -56,7 +56,9 @@ export const SelectMenu = (args) => {
 <Canvas>
     <Story
         args={{
-            label: "Select Menu"
+            label: "Select Menu",
+            inputId: 1,
+            labelId: 1
         }}
         name="Select Menu"
     >
@@ -103,7 +105,9 @@ export const Disabled = (args) => {
     <Story
         args={{
             label: "Disabled Select Menu",
-            disabled: true
+            disabled: true,
+            inputId: 1,
+            labelId: 1
         }}
         name="Disabled"
     >
@@ -145,7 +149,9 @@ export const Invalid = (args) => {
     <Story
         args={{
             label: "Invalid Select Menu",
-            invalid: true
+            invalid: true,
+            inputId: 1,
+            labelId: 1
         }}
         name="Invalid"
     >


### PR DESCRIPTION
## Brief Description

Audit for rux-select. Added variants, added css to prevent a disabled menu from changing border color on hover, updated the disabled prop description to match our other components, added inputId and labelId args in the stories mdx file to prevent them from showing up as 'undefined'. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1780 --> Audit
https://rocketcom.atlassian.net/browse/ASTRO-1596 --> input id and label id undefined 

## Related Issue

## General Notes

I just put `1` for the label and input ID on the storybook args. This kind of begs the question, maybe these should just be auto-incrementing values? That could be done pretty easily. 

## Motivation and Context

Storybook audit

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
