### PR TITLE
fix(rux-global-status-bar): overflow issue w/ pop up menu

### DIFF
--- a/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -18,10 +18,11 @@
     -ms-user-select: none;
     user-select: none;
 
-    contain: content; /* This improves CSS performance see: https://developers.google.com/web/updates/2016/06/css-containment */
+    contain: layout; /* This improves CSS performance see: https://developers.google.com/web/updates/2016/06/css-containment */
 }
 
 header {
+    overflow: hidden;
     display: flex;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## Brief Description

GSB had contain property set to 'content', which applies both 'layout' and 'paint'

https://css-tricks.com/almanac/properties/c/contain/

`paint` "is similar to applying overflow: hidden; to the element, but without the benefits of skipping or reducing needed calculations."


## JIRA Link

[ASTRO-1837](https://rocketcom.atlassian.net/browse/ASTRO-1837)

## Issues and Limitations

Fails regression test with smaller viewports. Our regression tests have a default viewport of 1024 px. Ill update that to reflect 1920 which should resolve this.

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [x] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
