### PR TITLE
ASTRO-1790 add extra params from docs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -126,6 +126,10 @@ export namespace Components {
          */
         "day"?: 'numeric' | '2-digit';
         /**
+          * Format options for era
+         */
+        "era"?: 'narrow' | 'short' | 'long';
+        /**
           * Format options for hour
          */
         "hour"?: 'numeric' | '2-digit';
@@ -157,6 +161,10 @@ export namespace Components {
           * Format options for Timezone name
          */
         "timeZoneName"?: 'short' | 'long';
+        /**
+          * Format options for weekday
+         */
+        "weekday"?: 'narrow' | 'short' | 'long';
         /**
           * Format options for year
          */
@@ -24345,6 +24353,10 @@ declare namespace LocalJSX {
          */
         "day"?: 'numeric' | '2-digit';
         /**
+          * Format options for era
+         */
+        "era"?: 'narrow' | 'short' | 'long';
+        /**
           * Format options for hour
          */
         "hour"?: 'numeric' | '2-digit';
@@ -24376,6 +24388,10 @@ declare namespace LocalJSX {
           * Format options for Timezone name
          */
         "timeZoneName"?: 'short' | 'long';
+        /**
+          * Format options for weekday
+         */
+        "weekday"?: 'narrow' | 'short' | 'long';
         /**
           * Format options for year
          */

--- a/src/components/rux-datetime/readme.md
+++ b/src/components/rux-datetime/readme.md
@@ -32,6 +32,7 @@ RuxDatetime is a utility component that provides a convenient wrapper around the
 | -------------- | ---------------- | -------------------------------- | ---------------------------------------------------------------------- | ------------ |
 | `date`         | `date`           | The date time to be formatted    | `Date \| string`                                                       | `new Date()` |
 | `day`          | `day`            | Format options for day           | `"2-digit" \| "numeric" \| undefined`                                  | `undefined`  |
+| `era`          | `era`            | Format options for era           | `"long" \| "narrow" \| "short" \| undefined`                           | `undefined`  |
 | `hour`         | `hour`           | Format options for hour          | `"2-digit" \| "numeric" \| undefined`                                  | `undefined`  |
 | `hour12`       | `hour-12`        | Display date in 12 hour time.    | `boolean`                                                              | `false`      |
 | `locale`       | `locale`         | The locale                       | `string`                                                               | `'default'`  |
@@ -40,6 +41,7 @@ RuxDatetime is a utility component that provides a convenient wrapper around the
 | `second`       | `second`         | Format options for second        | `"2-digit" \| "numeric" \| undefined`                                  | `undefined`  |
 | `timeZone`     | `time-zone`      | Format options for Timezone      | `string \| undefined`                                                  | `undefined`  |
 | `timeZoneName` | `time-zone-name` | Format options for Timezone name | `"long" \| "short" \| undefined`                                       | `undefined`  |
+| `weekday`      | `weekday`        | Format options for weekday       | `"long" \| "narrow" \| "short" \| undefined`                           | `undefined`  |
 | `year`         | `year`           | Format options for year          | `"2-digit" \| "numeric" \| undefined`                                  | `undefined`  |
 
 

--- a/src/components/rux-datetime/rux-datetime.tsx
+++ b/src/components/rux-datetime/rux-datetime.tsx
@@ -14,6 +14,14 @@ export class RuxDatetime {
      */
     @Prop() locale: string = 'default'
     /**
+     * Format options for weekday
+     */
+    @Prop() weekday?: 'narrow' | 'short' | 'long'
+    /**
+     * Format options for era
+     */
+    @Prop() era?: 'narrow' | 'short' | 'long'
+    /**
      * Format options for year
      */
     @Prop() year?: 'numeric' | '2-digit'
@@ -54,28 +62,32 @@ export class RuxDatetime {
         const date = new Date(this.date)
 
         const {
-            locale,
-            year,
-            month,
             day,
+            era,
             hour,
-            minute,
-            second,
-            timeZoneName,
-            timeZone,
             hour12,
+            locale,
+            minute,
+            month,
+            second,
+            timeZone,
+            timeZoneName,
+            weekday,
+            year,
         } = this
 
         return new Intl.DateTimeFormat(locale, {
-            year,
-            month,
             day,
+            era,
             hour,
-            minute,
-            second,
-            timeZoneName,
-            timeZone,
             hour12,
+            minute,
+            month,
+            second,
+            timeZone,
+            timeZoneName,
+            weekday,
+            year,
         }).format(date)
     }
 }

--- a/src/stories/classification-marking.stories.mdx
+++ b/src/stories/classification-marking.stories.mdx
@@ -1,7 +1,6 @@
 import { html, render } from 'lit-html'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
 import { extractArgTypes } from '@astrouxds/storybook-addon-docs-stencil'
-console.log(extractArgTypes('rux-classification-marking'))
 
 <Meta
     title="Components/Classification Markings"

--- a/src/stories/datetime.stories.mdx
+++ b/src/stories/datetime.stories.mdx
@@ -18,15 +18,18 @@ export const Default = (args) => {
         <div style="padding: 10%; display: flex; justify-content: center;">
           <rux-datetime
             date=${args.date}
-            .year="${args.year}"
-            .month="${args.month}"
-            .day="${args.day}"
-            .hour="${args.hour}"
-            .minute="${args.minute}"
-            .second="${args.second}"
-            .time-zone="${args.timeZone}"
+            .day=${args.day}
+            .era=${args.era}
+            .hour=${args.hour}
             .hour12=${args.hour12}
-            .time-zone-name="${args.timeZoneName}"
+            .locale=${args.locale}
+            .minute=${args.minute}
+            .month=${args.month}
+            .second=${args.second}
+            .timeZone=${args.timeZone}
+            .timeZoneName=${args.timeZoneName}
+            .weekday=${args.weekday}
+            .year=${args.year}
           ></rux-datetime>
         </div>
     `


### PR DESCRIPTION
## Brief Description

Audit `rux-datetime` component
Added few extra prams from the Intl.DateTimeFormat documentation


## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1790

## Related Issue

## General Notes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
