### PR TITLE
Add hover state to popup

### DIFF
--- a/src/components/rux-menu-item/readme.md
+++ b/src/components/rux-menu-item/readme.md
@@ -83,14 +83,14 @@ Pass properties as slotted components in the Astro Pop Up Menu or Astro Select M
 
 ## CSS Custom Properties
 
-| Name                             | Description                      |
-| -------------------------------- | -------------------------------- |
-| `--disabledCursor`               | Cursor for Disabled Items        |
-| `--disabledOpacity`              | Opacity for Disabled Items       |
-| `--menuItemBackgroundColor`      | Menu Item Background Color       |
-| `--menuItemHoverBackgroundColor` | Menu Item Hover Background Color |
-| `--menuItemHoverTextColor`       | Menu Item Hover Text Color       |
-| `--menuTextColor`                | Menu Text Color                  |
+| Name                                  | Description                      |
+| ------------------------------------- | -------------------------------- |
+| `--disabledCursor`                    | Cursor for Disabled Items        |
+| `--disabledOpacity`                   | Opacity for Disabled Items       |
+| `--popupMenuItemBackgroundColor`      | Menu Item Background Color       |
+| `--popupMenuItemHoverBackgroundColor` | Menu Item Hover Background Color |
+| `--popupMenuItemHoverTextColor`       | Menu Item Hover Text Color       |
+| `--popupMenuTextColor`                | Menu Text Color                  |
 
 
 ----------------------------------------------

--- a/src/components/rux-menu-item/rux-menu-item.scss
+++ b/src/components/rux-menu-item/rux-menu-item.scss
@@ -1,18 +1,18 @@
 :host {
     /**
-      * @prop --menuTextColor: Menu Text Color
+      * @prop --popupMenuTextColor: Menu Text Color
     */
 
     /**
-      * @prop --menuItemBackgroundColor: Menu Item Background Color
+      * @prop --popupMenuItemBackgroundColor: Menu Item Background Color
     */
 
     /**
-      * @prop --menuItemHoverBackgroundColor: Menu Item Hover Background Color
+      * @prop --popupMenuItemHoverBackgroundColor: Menu Item Hover Background Color
     */
 
     /**
-      * @prop --menuItemHoverTextColor: Menu Item Hover Text Color
+      * @prop --popupMenuItemHoverTextColor: Menu Item Hover Text Color
     */
 
     /**
@@ -34,21 +34,25 @@
         min-width: 15em;
         max-width: 20em;
 
-        background-color: --menuItemBackgroundColor;
+        background-color: var(--popupMenuItemBackgroundColor);
+        color: var(--popupMenuTextColor);
 
         &:hover {
-            background-color: var(--menuItemHoverBackgroundColor);
-            color: var(--menuItemHoverTextColor);
+            background-color: var(--popupMenuItemHoverBackgroundColor);
+            color: var(--popupMenuItemHoverTextColor);
         }
 
         a,
         div {
             text-overflow: ellipsis;
             text-decoration: none;
-            color: var(--menuTextColor);
+            color: var(--popupMenuTextColor);
             word-wrap: none;
             white-space: nowrap;
             overflow: hidden;
+            &:hover {
+                color: var(--popupMenuItemHoverTextColor);
+            }
         }
 
         a {

--- a/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
+++ b/src/components/rux-pop-up-menu/rux-pop-up-menu.scss
@@ -90,7 +90,6 @@ ul {
     list-style: none;
     padding: 0;
     margin: 0;
-
     background-color: var(--popupMenuBackgroundColor);
 
     z-index: 2;

--- a/src/components/rux-radio/readme.md
+++ b/src/components/rux-radio/readme.md
@@ -45,14 +45,16 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 
 ## CSS Custom Properties
 
-| Name                                  | Description                    |
-| ------------------------------------- | ------------------------------ |
-| `--controlBorderColor`                | Checkbox border color          |
-| `--controlHoverBorderColor`           | Checkbox border color on hover |
-| `--controlLabelColor`                 | Label text color               |
-| `--controlOutlineBackgroundColor`     | Checkbox background color      |
-| `--controlSelectedOutlineBorderColor` | Selected checkbox border color |
-| `--controlTextColor`                  | Selected checkbox icon color   |
+| Name                                      | Description                             |
+| ----------------------------------------- | --------------------------------------- |
+| `--controlBorderColor`                    | Radio border color                      |
+| `--controlHoverBorderColor`               | Radio border color on hover             |
+| `--controlLabelColor`                     | Label text color                        |
+| `--controlOutlineBackgroundColor`         | Radio background color                  |
+| `--controlSelectedBorderColor`            | Selected radio border color             |
+| `--controlSelectedOutlineBackgroundColor` | Selected radio outline background color |
+| `--controlSelectedOutlineBorderColor`     | Selected radio border color             |
+| `--controlTextColor`                      | Selected radio icon color               |
 
 
 ----------------------------------------------

--- a/src/components/rux-select/readme.md
+++ b/src/components/rux-select/readme.md
@@ -49,15 +49,15 @@ Select Menu renders a native `<select>` element and allows native `<option>` and
 
 ## Properties
 
-| Property   | Attribute  | Description                                            | Type                  | Default     |
-| ---------- | ---------- | ------------------------------------------------------ | --------------------- | ----------- |
-| `disabled` | `disabled` | Disables the item                                      | `boolean`             | `false`     |
-| `inputId`  | `input-id` | Id for the Select Input                                | `string \| undefined` | `undefined` |
-| `invalid`  | `invalid`  | Sets the Select as Invalid for Custom Validation Usage | `boolean`             | `false`     |
-| `label`    | `label`    | Sets the Label for the Select                          | `string \| undefined` | `undefined` |
-| `labelId`  | `label-id` | Id for the Label                                       | `string \| undefined` | `undefined` |
-| `name`     | `name`     | Sets the Name of the Input Element                     | `string \| undefined` | `undefined` |
-| `required` | `required` | Sets the field as required                             | `boolean`             | `false`     |
+| Property   | Attribute  | Description                                                                                                                                                                                       | Type                  | Default     |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `disabled` | `disabled` | Disables the select menu via HTML disabled attribute. Select menu takes on a distinct visual state. Cursor uses the not-allowed system replacement and all keyboard and mouse events are ignored. | `boolean`             | `false`     |
+| `inputId`  | `input-id` | Id for the Select Input                                                                                                                                                                           | `string \| undefined` | `undefined` |
+| `invalid`  | `invalid`  | Sets the Select as Invalid for Custom Validation Usage                                                                                                                                            | `boolean`             | `false`     |
+| `label`    | `label`    | Sets the Label for the Select                                                                                                                                                                     | `string \| undefined` | `undefined` |
+| `labelId`  | `label-id` | Id for the Label                                                                                                                                                                                  | `string \| undefined` | `undefined` |
+| `name`     | `name`     | Sets the Name of the Input Element                                                                                                                                                                | `string \| undefined` | `undefined` |
+| `required` | `required` | Sets the field as required                                                                                                                                                                        | `boolean`             | `false`     |
 
 
 ## Events

--- a/src/components/rux-tree/readme.md
+++ b/src/components/rux-tree/readme.md
@@ -47,6 +47,13 @@ TreeNode has two slots:
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description            |
+| ------------- | ---------------------- |
+| `"(default)"` | the nodes of the tree. |
+
+
 ## CSS Custom Properties
 
 | Name                    | Description           |

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -507,7 +507,7 @@ $quaternary: (
     --popupMenuItemBackgroundColor: var(--backgroundColor);
     //equates to --colorSnowflakesDarkSelected with alpha of 0.3
     --popupMenuItemHoverBackgroundColor: rgba(28, 63, 94, 0.3);
-    --popupMenuItemHoverTextColor: var(--primaryLight);
+    --popupMenuItemHoverTextColor: var(--colorSecondaryLighten2);
 
     --popupMenuItemSeparatorBorderColor: var(--primaryDarker);
     --menuItemDividerBorderColor: var(--primaryDarker);

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -507,7 +507,7 @@ $quaternary: (
     --popupMenuItemBackgroundColor: var(--backgroundColor);
     //equates to --colorSnowflakesDarkSelected with alpha of 0.3
     --popupMenuItemHoverBackgroundColor: rgba(28, 63, 94, 0.3);
-    --popupMenuItemHoverTextColor: var(--colorSecondaryLighten2);
+    --popupMenuItemHoverTextColor: var(--primaryLight);
 
     --popupMenuItemSeparatorBorderColor: var(--primaryDarker);
     --menuItemDividerBorderColor: var(--primaryDarker);


### PR DESCRIPTION


## Brief Description

This added hover state to pop-up-menu-items. I think the css vars got updated in variables.scss but not inside the component. Also updated the hover text color to be the correct value, as per abstract

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1821

## Related Issue

## General Notes

## Motivation and Context

Adds missing hover state.

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
