### PR TITLE
React docs update

### DIFF
--- a/src/stories/welcome/react.stories.mdx
+++ b/src/stories/welcome/react.stories.mdx
@@ -139,7 +139,7 @@ import React, { createRef } from "react";
 import { RuxButton, RuxTree, RuxTreeNode } from "@astrouxds/react";
 
 class Tree extends React.Component {
-  private treeRef = createRef();
+  treeRef = createRef();
 
   render() {
     return (

--- a/src/stories/welcome/react.stories.mdx
+++ b/src/stories/welcome/react.stories.mdx
@@ -87,7 +87,7 @@ const MyComp = () => {
     return (
         <div>
             <RuxInputField 
-                onRux-change={() => handleChange()}
+                onRux-input={() => console.log('Heard ruxInput!')}
             />
         </div>
     )
@@ -96,6 +96,9 @@ const MyComp = () => {
 It is **highly** encouraged to listen to these custom events rather than default React events such as onChange. Because some 
 React events are different from their native JS counterparts, some bugs can arise from using default React 
 events. 
+
+Because Astro components were built using [Stencil](https://stenciljs.com/), the custom events were named following the JavaScript convention. React handles onChange differently than JavaScript, therefore the `onRux-input`
+is the equivalent of React's onChange. [React onChange event docs.](https://reactjs.org/docs/dom-elements.html#onchange)
 
 ## Methods
 

--- a/src/stories/welcome/react.stories.mdx
+++ b/src/stories/welcome/react.stories.mdx
@@ -97,7 +97,7 @@ It is **highly** encouraged to listen to these custom events rather than default
 React events are different from their native JS counterparts, some bugs can arise from using default React 
 events. 
 
-Because Astro components were built using [Stencil](https://stenciljs.com/), the custom events were named following the JavaScript convention. React handles onChange differently than JavaScript, therefore the `onRux-input`
+Because Astro components were built using [Stencil](https://stenciljs.com/), the custom events were named following the JavaScript convention. React handles onChange differently than JavaScript, therefore the `onRux-input` event
 is the equivalent of React's onChange. [React onChange event docs.](https://reactjs.org/docs/dom-elements.html#onchange)
 
 ## Methods


### PR DESCRIPTION
## Brief Description

Updated the listening to events section to better document why devs should use onRux-input instead of React's default onChange. Removed a TS specific `private` tag.
All code snippets were run in a react app following the docs word for word, so we should be good now.

## Related Issue

## General Notes

## Motivation and Context

Improvement to the react docs

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
