### PR TITLE
Astro 1833 svelte docs

### DIFF
--- a/src/stories/welcome/svelte.stories.mdx
+++ b/src/stories/welcome/svelte.stories.mdx
@@ -28,7 +28,7 @@ You have two options for importing Astro Web Components: Lazy Loading and Cherry
 
 #### Lazy Loading
 
-Astro Web Components make use of Stencil's automatic lazy loader which only loads components that are actually used on the page. In order to begin using the components and have themy styled correctly you will need to make some changes to the main.js file in your source folder. First, import the @astrouxds/astro-web-components main CSS. Then, import `defineCustomElements` from the @astrouxds node module and call it. After making those changes all Astro compoennts are able to be used by simply using their associated custom html tag such as `<rux-button>` or `<rux-icon>` within a Svelte component.
+Astro Web Components make use of Stencil's automatic lazy loader which only loads components that are actually used on the page. In order to begin using the components and have them styled correctly you will need to make some changes to the main.js file in your source folder. First, import the @astrouxds/astro-web-components main CSS. Then, import `defineCustomElements` from the @astrouxds node module and call it. After making those changes all Astro compoennts are able to be used by simply using their associated custom html tag such as `<rux-button>` or `<rux-icon>` within a Svelte component.
 
 ```js
 // main.js
@@ -121,6 +121,7 @@ Props are set the same way as any other Svelte component. Both primitive and com
     },
   ];
 </script>
+
 <!-- {range} prop is equivlent to range={range} -->
 <main>
   <rux-monitoring-progress-icon
@@ -139,7 +140,6 @@ Slots give you full control over the contents of a component. Some components ma
 
 > Web Component Concept:
 > Slotted content lives outside of the shadow DOM and as a result, you are free to style them however you want.
-
 
 ```html
 <rux-global-status-bar>
@@ -200,7 +200,7 @@ Some components offer public methods that can be executed. These methods are asy
 
 There is a limitation with Svelte and data binding on custom elements. Svelte's two-way binding syntax `bind:[prop]` is not supproted for custom element props. 
 
-The syntax in this example will *not* work as it will with native elements
+The syntax in this example will **not** work as it will with native elements
 ```html
 <script>
   let name

--- a/src/stories/welcome/svelte.stories.mdx
+++ b/src/stories/welcome/svelte.stories.mdx
@@ -1,0 +1,237 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Astro UXDS/Welcome/Svelte" />
+
+# Svelte Integration
+
+## Svelte Project Setup
+
+A Svelte project can be set up using Svelte's recommended project scaffolding tool degit. Run the following commands from the directory where you would like to create the project and you will have a working project template to start building off of.
+
+```
+npx degit sveltejs/template my-svelte-project
+cd my-svelte-project
+# to use TypeScript run:
+# node scripts/setupTypeScript.js
+
+npm install
+npm run dev
+```
+
+## Astro Installation
+
+### Via NPM
+
+`npm i @astrouxds/astro-web-components`
+
+You have two options for importing Astro Web Components: Lazy Loading and Cherry Picking.
+
+#### Lazy Loading
+
+Astro Web Components make use of Stencil's automatic lazy loader which only loads components that are actually used on the page. In order to begin using the components and have themy styled correctly you will need to make some changes to the main.js file in your source folder. First, import the @astrouxds/astro-web-components main CSS. Then, import `defineCustomElements` from the @astrouxds node module and call it. After making those changes all Astro compoennts are able to be used by simply using their associated custom html tag such as `<rux-button>` or `<rux-icon>` within a Svelte component.
+
+```js
+// main.js
+import App from "./App.svelte";
+
+// Import Astro's base styles
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
+// Define the Astro Components
+import { defineCustomElements } from '@astrouxds/astro-web-components/dist/custom-elements';
+defineCustomElements();
+
+const app = new App({
+  target: document.body,
+});
+
+export default app;
+```
+
+#### Cherry Picking
+
+If you need more control over your bundle size, you can also import and register individual components. Cherry picking components will result in a much smaller overall bundle size; however, you will need to manually register any component dependencies. This will be listed for each component in their documentation.
+
+```js
+// main.js
+import App from "./App.svelte";
+// Import Astro's base styles
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css'
+// Import Button
+import { RuxButton } from '@astrouxds/astro-web-components/dist/components/rux-button'
+// Register Button
+customElements.define('rux-button', RuxButton)
+
+const app = new App({
+  target: document.body,
+});
+
+export default app;
+```
+
+Import [Roboto](https://fonts.google.com/specimen/Roboto) in your index.html. We recommend using Google's CDN for ease of use but you can also install it locally.
+
+```html
+<link rel="preconnect" href="https://fonts.gstatic.com" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap" rel="stylesheet"/>
+```
+
+## Using Astro in Svelte
+
+Svelte has [excellent support for Web Components](https://custom-elements-everywhere.com/libraries/svelte/results/results.html). However, there are some situiations where Svelte syntax is not available and Astro may not behave as expected. Below are examples of how to use Astro in Svelte for common patterns.
+
+### Setting Props
+
+Props are set the same way as any other Svelte component. Both primitive and complex data types can be passed through props. 
+
+#### Basic Data
+```html
+<main>
+  <!-- Note that properties must be in kebab case -->
+  <rux-button icon="solar" icon-only size="large">Button</rux-button>
+</main>
+```
+
+#### Complex Data
+```html
+<script>
+  let range = [
+    {
+      threshold: 17,
+      status: "off",
+    },
+    {
+      threshold: 33,
+      status: "standby",
+    },
+    {
+      threshold: 49,
+      status: "normal",
+    },
+    {
+      threshold: 65,
+      status: "caution",
+    },
+    {
+      threshold: 81,
+      status: "serious",
+    },
+    {
+      threshold: 100,
+      status: "critical",
+    },
+  ];
+</script>
+<!-- {range} prop is equivlent to range={range} -->
+<main>
+  <rux-monitoring-progress-icon
+    progress="65"
+    max="100"
+    min="0"
+    label="label"
+    {range}
+  />
+</main>
+```
+
+### Using Slots
+
+Slots give you full control over the contents of a component. Some components may have multiple slots.
+
+> Web Component Concept:
+> Slotted content lives outside of the shadow DOM and as a result, you are free to style them however you want.
+
+
+```html
+<rux-global-status-bar>
+  <rux-icon slot="left-side" icon="apps"></rux-icon>
+  <div slot="app-meta">
+    <h1>Hello World</h1>
+  </div>
+</rux-global-status-bar>
+```
+
+### Listening to Events
+
+Astro Components emit their own custom events, prefixed with `rux`. You will likely use these to sync state between your Svelte components and the Astro Web Components. Events can be listened to by using Svelte's `on:[event]` syntax. 
+
+```html
+<script>
+  function sayHello(event) {
+    alert("Hello!");
+  }
+</script>
+
+<div>
+  <rux-checkbox on:rux-change={sayHello}> Click to say hello </rux-checkbox>
+</div>
+```
+
+### Methods
+
+Some components offer public methods that can be executed. These methods are async and can be executed by setting a ref on the element. The ref is set using Svelte's 'bind:this' syntax. Then the method can be called on the ref.
+
+```html
+<script>
+  // Element reference declared
+  let PopUpElement;
+
+  const handleClick = (e) => {
+    // Public show() method called here
+    PopUpElement.show();
+  };
+</script>
+
+<div>
+  <rux-icon icon="apps" aria-controls="popup-menu-1" />
+  <!-- Element reference linked using Svelte syntax -->
+  <rux-pop-up-menu id="popup-menu-1" bind:this={PopUpElement}>
+    <rux-menu-item>Item 1</rux-menu-item>
+    <rux-menu-item-divider />
+    <rux-menu-item value="2">Item 2</rux-menu-item>
+    <rux-menu-item disabled>Item 3 is disabled</rux-menu-item>
+    <rux-menu-item value="Item 4">Item 4 has a string value</rux-menu-item>
+    <rux-menu-item href="https://www.astrouxds.com">Item 5 is an anchor</rux-menu-item>
+  </rux-pop-up-menu>
+  <rux-button on:click={handleClick}>Show pop up using show() method</rux-button>
+</div>
+```
+
+## Data Binding
+
+There is a limitation with Svelte and data binding on custom elements. Svelte's two-way binding syntax `bind:[prop]` is not supproted for custom element props. 
+
+The syntax in this example will *not* work as it will with native elements
+```html
+<script>
+  let name
+  
+</script>
+
+<div>
+  <!-- The bind syntax below will throw and error -->
+  <rux-input-field bind:value={name} />
+  <h1>Hello {name}!</h1>
+</div>
+```
+
+Data binding must be done manually by creating an event handler and listening to the custom events emitted by Astro Components. This will most commonly occur with form elements.
+```html
+<script>
+  let name;
+
+  const handleInput = (e) => {
+    name = e.target.value;
+  };
+</script>
+
+<div>
+  <rux-input-field
+    on:rux-input={handleInput}
+  />
+
+  <h1>Hello {name}!</h1>
+</div>
+```
+
+
+

--- a/src/stories/welcome/svelte.stories.mdx
+++ b/src/stories/welcome/svelte.stories.mdx
@@ -4,21 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 # Svelte Integration
 
-## Svelte Project Setup
-
-A Svelte project can be set up using Svelte's recommended project scaffolding tool degit. Run the following commands from the directory where you would like to create the project and you will have a working project template to start building off of.
-
-```
-npx degit sveltejs/template my-svelte-project
-cd my-svelte-project
-# to use TypeScript run:
-# node scripts/setupTypeScript.js
-
-npm install
-npm run dev
-```
-
-## Astro Installation
+## Installation
 
 ### Via NPM
 


### PR DESCRIPTION
## Brief Description

Adds documentation for set up and integration of Astro into a Svelte project.

## JIRA Link

[ASTRO-1833](https://rocketcom.atlassian.net/browse/ASTRO-1833)

## General Notes

All code examples were tested and work as expected. I included a section for setting up a Svelte Project but that may not be necessary. 

## Motivation and Context

Supports use of Astro in Svelte without wrapped components. 

## Issues and Limitations

MDX code block syntax (```Svelte ```) does not provide color coding so I reverted to using html.

## Types of changes

-   [ ] Bug fix
-   [X] New feature
-   [ ] Breaking change

## Checklist

-   [X] My code follows the code style of this project.
-   [X] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
