### PR TITLE
refactor(tree): removed unused css props

### DIFF
--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -574,21 +574,15 @@ $quaternary: (
     --treeTextColor: var(--defaultText);
     --treeBackgroundColor: var(--surfaceElements);
     --treeBorderColor: var(--primaryDark);
-    --treeItemBorderColor: var(--primaryDark);
     --treeAccentColor: var(--primary);
 
     /* Hover*/
     --treeHoverBackgroundColor: var(--primaryLight);
     --treeHoverTextColor: var(--primaryElementText);
-    --treeHoverAccentColor: var(--primary);
 
     /* Selected */
-    --treeSelectedBackgroundColor: var(--surfaceElements);
     --treeSelectedBorderColor: var(--primaryDark);
-    --treeSelectedTextColor: var(--defaultText);
     --treeSelectedAccentColor: var(--primary);
-
-    --treeChildrenBackgroundColor: var(--surfaceElements);
 
     --treeExpandedBorderColor: var(--backgroundColor);
 


### PR DESCRIPTION
## Brief Description

Gets rid of unused CSS custom props for rux-tree and rux-tree-node. 
Light and dark regressions passing.

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1920 --> tree
https://rocketcom.atlassian.net/browse/ASTRO-1919 --> tree-node

## Related Issue
CSS Refactor Story: https://rocketcom.atlassian.net/browse/ASTRO-1855
## General Notes

## Motivation and Context

Removes unused css custom props.

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
