### PR TITLE
refactor(tabs): got rid of unused css class

### DIFF
--- a/src/components/rux-tabs/rux-tabs.scss
+++ b/src/components/rux-tabs/rux-tabs.scss
@@ -1,9 +1,7 @@
-:host,
-.rux-tabs {
+:host {
     /**
     *   @prop --tabBorderColor: Tab border color
     */
-    --tabBorderColor: transparent;
     box-sizing: border-box;
     display: flex;
     justify-content: flex-start;
@@ -20,14 +18,10 @@
     user-select: none;
     contain: content; /* This improves CSS performance see: https://developers.google.com/web/updates/2016/06/css-containment */
 }
-
 :host([hidden]) {
     display: none;
 }
 
-.rux-tabs .rux-tab {
-    border-bottom: 5px solid var(--tabBorderColor);
-}
 :host([small]) {
     min-height: 3.125rem;
     font-size: 1rem;


### PR DESCRIPTION
## Brief Description

Removes CSS class that wasn't doing anything, and removes a global css custom prop definition from rux-tabs.

## JIRA Link

Tabs --> https://rocketcom.atlassian.net/browse/ASTRO-1917
Tab --> https://rocketcom.atlassian.net/browse/ASTRO-1915 (Tab had no changes)

## Related Issue

## General Notes

## Motivation and Context
Cleans up tabs scss

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have added tests to cover my changes.
