### PR TITLE
refactor(monitoring-progress-icon): removed unused css class

### DIFF
--- a/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
+++ b/src/components/rux-monitoring-progress-icon/rux-monitoring-progress-icon.scss
@@ -18,11 +18,8 @@
     flex-direction: column;
     justify-content: flex-start;
     position: relative;
-
     margin: 0;
-
     line-height: 0;
-
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -32,15 +29,6 @@
 .rux-advanced-status__icon-group {
     display: flex;
     position: relative;
-
-    margin: 0 auto;
-    width: 4.5rem;
-}
-
-.icon-template-wrapper {
-    display: flex;
-    position: relative;
-
     margin: 0 auto;
     width: 4.5rem;
 }
@@ -56,22 +44,18 @@ rux-status {
     display: block;
     z-index: 2;
     order: 3;
-
     position: absolute;
     bottom: -0.75rem;
     right: -0.4rem;
-
     border: 1px solid rgba(255, 255, 255, 0.6);
     border-radius: 3px;
     padding: 0.65rem 0.25rem;
-
     color: #fff;
     font-size: 0.775rem;
     text-align: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
     background-color: #000;
 }
 
@@ -83,9 +67,7 @@ rux-status {
     white-space: nowrap;
     line-height: 1.2;
     overflow: hidden;
-
     margin-top: 1rem;
-
     width: 100%;
     max-width: 6.25rem;
 }
@@ -146,16 +128,12 @@ svg.rux-status--critical {
     margin-top: -0.125rem;
     margin-left: -0.125rem;
     font-size: 0.8rem;
-
     position: absolute;
-
     display: flex;
     justify-content: center;
     align-items: center;
-
     width: 100%;
     height: 100%;
-
     letter-spacing: -0.0625rem;
     text-align: center;
 }


### PR DESCRIPTION
## Brief Description

Removed the icon-template-wrapper class from the scss. It's not being used on any of the icon tsx files that I saw. @Full-lifey , did I miss where it's being used? 
Regressions passing for all icons. 

## JIRA Link

https://rocketcom.atlassian.net/browse/ASTRO-1903

## Related Issue

## General Notes

## Motivation and Context

SCSS cleanup

## Issues and Limitations

## Types of changes

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
