### PR TITLE
style(modal): added color values, box-sizing

### DIFF
--- a/src/components/rux-modal/rux-modal.scss
+++ b/src/components/rux-modal/rux-modal.scss
@@ -2,18 +2,31 @@
 
 :host {
     /**
-      * @prop --modalTitleColor: Modal title color
-      * @prop --modalTextColor: Modal text color
-      * @prop --modalBackgroundColor: Modal background color
-      * @prop --modalBorderColor: Modal border color
-      */
-
-    /**
-      * @part wrapper - css part hook to style modal wrapper
+    * @part wrapper - css part hook to style modal wrapper
     */
 
+    /**
+    * @prop --modal-title-color: Modal title color
+    */
+    --modal-title-color: var(--inverse-text);
+
+    /**
+    * @prop --modal-background-color: Modal background color
+    */
+    --modal-background-color: var(--surface);
+
+    /**
+    * @prop --modal-border-color: Modal border color
+    */
+    --modal-border-color: var(--primary);
 
     display: contents;
+}
+
+*,
+*:before,
+*:after {
+    box-sizing: inherit;
 }
 
 //  this styling is only used in storybook up for presentational purposes
@@ -43,7 +56,7 @@ rux-button-group {
         align-items: center;
         z-index: 1100;
         background-color: rgba(0, 0, 0, 0.5);
-        @include mixins.animation(fadeIn, 0.5s);
+        // @include mixins.animation(fadeIn, 0.5s);
     }
     &__dialog {
         position: relative;

--- a/src/components/rux-modal/rux-modal.scss
+++ b/src/components/rux-modal/rux-modal.scss
@@ -56,7 +56,7 @@ rux-button-group {
         align-items: center;
         z-index: 1100;
         background-color: rgba(0, 0, 0, 0.5);
-        // @include mixins.animation(fadeIn, 0.5s);
+        @include mixins.animation(fadeIn, 0.5s);
     }
     &__dialog {
         position: relative;

--- a/src/components/rux-modal/rux-modal.scss
+++ b/src/components/rux-modal/rux-modal.scss
@@ -107,14 +107,13 @@ rux-button-group {
     &__message {
         margin: 0.5rem 1.875rem 2.5rem 1.875rem;
     }
+    .rux-button {
+        box-shadow: none !important;
+    }
 }
 
 rux-icon {
     margin-right: 0.75rem;
-}
-
-.rux-modal .rux-button {
-    box-shadow: none !important;
 }
 
 @include mixins.keyframes(fadeIn) {


### PR DESCRIPTION
## Brief Description

Adds in the color values for modal, and adds back in box-sizing in order to pass regressions. Also moved the .rux-button selector inside of .rux-modal

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1901

## Related Issue

## General Notes

## Motivation and Context
Our current next deployed site has a really broken looking modal. The CSS custom props aren't in _variables.scss, or the modal component itself, so I added those back in. 

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
