### PR TITLE
Astro 1950 classification marking fix

### DIFF
--- a/src/components/rux-classification-marking/rux-classification-marking.tsx
+++ b/src/components/rux-classification-marking/rux-classification-marking.tsx
@@ -16,7 +16,7 @@ export class RuxClassificationMarking {
     /**
      * Defines which classification marking will be displayed.
      */
-    @Prop() classification: Classification = 'unclassified'
+    @Prop({ reflect: true }) classification: Classification = 'unclassified'
     /**
      * Allows additional text labels to be added to the a marking
      */

--- a/src/components/rux-classification-marking/test/rux-classification-marking.spec.tsx
+++ b/src/components/rux-classification-marking/test/rux-classification-marking.spec.tsx
@@ -19,7 +19,7 @@ describe('rux-classification-marking', () => {
             html: `<rux-classification-marking></rux-classification-marking>`,
         })
         expect(page.root).toEqualHtml(`
-      <rux-classification-marking>
+      <rux-classification-marking classification="unclassified">
         <mock:shadow-root>
           <div class="rux-classification rux-classification--banner">
             unclassified

--- a/src/components/rux-clock/rux-clock.tsx
+++ b/src/components/rux-clock/rux-clock.tsx
@@ -49,7 +49,7 @@ export class RuxClock {
     /**
      * Applies a smaller clock style.
      */
-    @Prop() small: boolean = false
+    @Prop({ reflect: true }) small: boolean = false
 
     @Watch('timezone')
     timezoneChanged() {

--- a/src/components/rux-notification/rux-notification.tsx
+++ b/src/components/rux-notification/rux-notification.tsx
@@ -17,7 +17,11 @@ export class RuxNotification {
     /**
      *  The background color. Possible values include 'standby', 'normal', 'caution', and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
      */
-    @Prop() status: 'standby' | 'normal' | 'caution' | 'critical' = 'standby'
+    @Prop({ reflect: true }) status:
+        | 'standby'
+        | 'normal'
+        | 'caution'
+        | 'critical' = 'standby'
     /**
      *  If provided, the banner will automatically close after this amount of time. Accepts value either in milliseconds or seconds (which will be converted to milliseconds internally), between `2000` and `10000`, or `2` and `10`, respectively. Any number provided outside of the `2000`-`10000` range will be ignored in favor of the default 2000ms delay. <br>If `closeAfter` is not passed or if it is given an undefined or `null` value, the banner will stay open until the user closes it.
      */

--- a/src/components/rux-notification/test/rux-notification.spec.tsx
+++ b/src/components/rux-notification/test/rux-notification.spec.tsx
@@ -10,7 +10,7 @@ describe('rux-notification', () => {
             html: `<rux-notification open message="hello there"></rux-notification>`,
         })
         expect(page.root).toEqualHtml(`
-         <rux-notification message="hello there" open="">
+         <rux-notification message="hello there" open="" status="standby">
            <mock:shadow-root>
              <div class="rux-notification__message">
                hello there

--- a/src/stories/monitoring-icon.stories.mdx
+++ b/src/stories/monitoring-icon.stories.mdx
@@ -47,9 +47,6 @@ export const Default = (args) => {
           label: 'Monitoring',
           notifications: 1
         }}
-        parameters={{
-            docs: { source: { code: '<rux-button>Button</rux-button>' } },
-        }}
         name="Default"
     >
         {Default.bind()}


### PR DESCRIPTION
## Brief Description

Fixes bugs where styling was not updating if props were updated via js
Fixes incorrect code example for monitoring icon

## JIRA Link

[ASTRO-1950](https://rocketcom.atlassian.net/browse/ASTRO-1950)

## Motivation and Context

The ticket is just for classification marking, but the same issue applies for clock, monitoring icon, and notification so I just updated them as part of this. 

The issue comes down to those components have attribute-specific styling instead of css classes (ie :host([status=foo]) ... ). Because those properties weren't being reflected back to the attribute, the styling wasn't taking effect. 

Alternatively, we could have removed styling attributes and replaced them with classes. 

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
