### PR TITLE
Astro 1942 rux menu item width

### DIFF
--- a/src/components/rux-menu-item/rux-menu-item.scss
+++ b/src/components/rux-menu-item/rux-menu-item.scss
@@ -27,9 +27,6 @@
         font-size: 1rem;
         overflow: hidden;
 
-        min-width: 15em;
-        max-width: 20em;
-
         background-color: var(--popup-menu-item-background-color);
         color: var(--popup-menu-text-color);
 

--- a/src/components/rux-modal/readme.md
+++ b/src/components/rux-modal/readme.md
@@ -71,9 +71,9 @@ Pass properties as attributes of the Astro Rux Modal custom element:
 
 ## Shadow Parts
 
-| Part        | Description |
-| ----------- | ----------- |
-| `"wrapper"` |             |
+| Part        | Description               |
+| ----------- | ------------------------- |
+| `"wrapper"` | the modal wrapper overlay |
 
 
 ## CSS Custom Properties

--- a/src/components/rux-modal/rux-modal.tsx
+++ b/src/components/rux-modal/rux-modal.tsx
@@ -10,6 +10,10 @@ import {
     Host,
 } from '@stencil/core'
 
+/**
+ * @part wrapper - the modal wrapper overlay
+ *
+ */
 @Component({
     tag: 'rux-modal',
     styleUrl: 'rux-modal.scss',

--- a/src/stories/popup.stories.mdx
+++ b/src/stories/popup.stories.mdx
@@ -36,7 +36,7 @@ export const Default = (args) => {
              <rux-pop-up-menu id="popup-menu-1" .open="${args.open}">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -185,7 +185,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-1">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -200,7 +200,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-2">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -215,7 +215,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-3">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -230,7 +230,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-4">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -245,7 +245,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-5">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -260,7 +260,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-6">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >
@@ -275,7 +275,7 @@ export const WithAnchors = (args) => {
             <rux-pop-up-menu id="popup-menu-7">
                 <rux-menu-item>Item 1</rux-menu-item>
                 <rux-menu-item-divider></rux-menu-item-divider>
-                <rux-menu-item value="2"
+                <rux-menu-item value="2" style="max-width: 344px"
                     >Item 2 with an exceedingly long title that overruns the
                     width</rux-menu-item
                 >


### PR DESCRIPTION
## Brief Description

Removes min and max width css properties in rux-menu-item to allow for more control over width or pop-up menu. Stories have been updated with line style to maintain visual regression test passing.

## JIRA Link

[ASTRO-1942](https://rocketcom.atlassian.net/browse/ASTRO-1942)

## Related Issue

Also this PR adds a shadow part description for modal that was missing.

## Types of changes

-   [ ] Bug fix
-   [X] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
