### PR TITLE
style(popup): fixed hover state, stencil build

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12024,7 +12024,10 @@ export namespace Components {
         /**
           * The background color. Possible values include 'standby', 'normal', 'caution', and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
          */
-        "status": 'standby' | 'normal' | 'caution' | 'critical';
+        "status": | 'standby'
+        | 'normal'
+        | 'caution'
+        | 'critical';
     }
     interface RuxPopUpMenu {
         /**
@@ -32073,7 +32076,10 @@ declare namespace LocalJSX {
         /**
           * The background color. Possible values include 'standby', 'normal', 'caution', and 'critical'. See [Astro UXDS Status System](https://astrouxds.com/patterns/status-system/).
          */
-        "status"?: 'standby' | 'normal' | 'caution' | 'critical';
+        "status"?: | 'standby'
+        | 'normal'
+        | 'caution'
+        | 'critical';
     }
     interface RuxPopUpMenu {
         /**

--- a/src/components/rux-menu-item/rux-menu-item.scss
+++ b/src/components/rux-menu-item/rux-menu-item.scss
@@ -17,7 +17,8 @@
     /**
       * @prop --popup-menu-item-hover-background-color: Menu Item Hover Text Color
     */
-    --popup-menu-item-hover-background-color: var(--hover);
+    // --popup-menu-item-hover-background-color: var(--hover);
+    --popup-menu-item-hover-text-color: var(--hover);
 
     display: block;
 
@@ -35,7 +36,7 @@
 
         &:hover {
             background-color: var(--popup-menu-item-hover-background-color);
-            color: var(--popup-menu-item-hover-background-color);
+            color: var(--popup-menu-item-hover-text-color);
         }
 
         a,
@@ -46,9 +47,6 @@
             word-wrap: none;
             white-space: nowrap;
             overflow: hidden;
-            &:hover {
-                color: var(--popup-menu-item-hover-background-color);
-            }
         }
 
         a {


### PR DESCRIPTION
## Brief Description

Fixes incorrect hover state for popup menu.

## JIRA Link
https://rocketcom.atlassian.net/browse/ASTRO-1956

## Related Issue

## General Notes

## Motivation and Context

Pop up menu hover state was using the same variable for color and background

## Issues and Limitations

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
