### PR TITLE
Astro 1926 gsb tabs bug

### DIFF
--- a/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -1,3 +1,5 @@
+@use "../../global/variables" as variables;
+
 :host {
     display: block;
     position: sticky;
@@ -123,4 +125,9 @@ slot[name='left-side'] > .shifted-up,
     display: inline-flex;
     justify-content: center;
     flex-basis: 100%;
+}
+
+//Preserves dark theme defaults for slotted elements in GSB
+::slotted(*) {
+    @include variables.root-variables;
 }

--- a/src/components/rux-global-status-bar/rux-global-status-bar.scss
+++ b/src/components/rux-global-status-bar/rux-global-status-bar.scss
@@ -127,7 +127,7 @@ slot[name='left-side'] > .shifted-up,
     flex-basis: 100%;
 }
 
-//Preserves dark theme defaults for slotted elements in GSB
+//Preserves dark theme defaults for slotted elements in GSB since content must always be rendered in dark theme.
 ::slotted(*) {
     @include variables.root-variables;
 }

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -1,4 +1,4 @@
-:root {
+@mixin root-variables {
     --background: #101923;
     --global-status-bar: #172635;
     --surface: #1b2d3e;
@@ -165,4 +165,8 @@
     --color-scrollbar-background-thumb-hover: #3a81bf;
     --color-scrollbar-background-track: #203246;
     --color-scrollbar-corner-background: #203246;
+}
+
+:root {
+    @include root-variables;
 }

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -1,3 +1,9 @@
+:root {
+    @include root-variables;
+}
+
+// Dark/Default Theme Variables Mixin.
+// This a mixin to allow for variables to be included in the shadow dom of a component and overwrite global thmese when necessary.
 @mixin root-variables {
     --background: #101923;
     --global-status-bar: #172635;
@@ -165,8 +171,4 @@
     --color-scrollbar-background-thumb-hover: #3a81bf;
     --color-scrollbar-background-track: #203246;
     --color-scrollbar-corner-background: #203246;
-}
-
-:root {
-    @include root-variables;
 }

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -2,7 +2,7 @@
     @include root-variables;
 }
 
-// Dark/Default Theme Variables Mixin.
+// Dark/Default Theme Variables Mixin
 // This a mixin to allow for variables to be included in the shadow dom of a component and overwrite global thmese when necessary.
 @mixin root-variables {
     --background: #101923;

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -169,6 +169,7 @@
     --color-scrollbar-corner-background: #203246;
 }
 
+// Sets default theme variables for component library
 :root {
     @include root-variables;
 }

--- a/src/global/_variables.scss
+++ b/src/global/_variables.scss
@@ -1,7 +1,3 @@
-:root {
-    @include root-variables;
-}
-
 // Dark/Default Theme Variables Mixin
 // This a mixin to allow for variables to be included in the shadow dom of a component and overwrite global thmese when necessary.
 @mixin root-variables {
@@ -171,4 +167,8 @@
     --color-scrollbar-background-thumb-hover: #3a81bf;
     --color-scrollbar-background-track: #203246;
     --color-scrollbar-corner-background: #203246;
+}
+
+:root {
+    @include root-variables;
 }


### PR DESCRIPTION
## Brief Description

Tabs used in the GSB were using the light-theme global css variables while being within the GSB which is only dark theme. This revealed a larger bug in that all children within the GSB should maintain dark theme default variables even when the surrounding application switches to light theme. 

To solve this I changed our root default theme/color variables into a sass mixin. The mixin is still included in the _variables.scss file so it is as if they are still located there but can also be imported into other files. Then within GSB I target slotted children and imported the dark theme variables so they would overwrite .light-theme within the shadow DOM.

## JIRA Link

[ASTRO-1926](https://rocketcom.atlassian.net/browse/ASTRO-1926)

## General Notes

I feel very unsure if this is the write approach since it seems like it could have ramifications on our styles that I am not seeing. However, the ability to import the variables to specific components seems like it could also have uses down the line as we want to customize our component styles.

## Motivation and Context

Preserve consistent styling within GSB.

## Types of changes

-   [X] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
