### PR TITLE
build(core): add appendChildSlotFix polyfill

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,11 +1,18 @@
 import { Config } from '@stencil/core'
 import { sass } from '@stencil/sass'
 import { svgOptimizerPlugin } from './src/utils/rollup-svg'
+// import { reactOutputTarget } from '@stencil/react-output-target';
 
 export const config: Config = {
     namespace: 'astro-web-components',
     globalStyle: 'src/global/global.scss',
     outputTargets: [
+        // reactOutputTarget({
+        //   componentCorePackage: '@astrouxds/astro-web-components',
+        //   proxiesFile: '../astro-in-react/src/components.ts',
+        //   includePolyfills: true,
+        //   includeDefineCustomElements: true
+        // }),
         {
             type: 'dist',
             esmLoaderPath: '../loader',
@@ -36,4 +43,7 @@ export const config: Config = {
     ],
     plugins: [sass(), svgOptimizerPlugin()],
     enableCache: true,
+    extras: {
+        appendChildSlotFix: true,
+    },
 }


### PR DESCRIPTION
## Brief Description

Fixes https://github.com/RocketCommunicationsInc/astro-components-stencil/discussions/233 where option slots weren't rendering correctly in React for Select

This requires two additional flags to the react output config. They're commented out for now. 

## JIRA Link

[ASTRO-2034](https://rocketcom.atlassian.net/browse/ASTRO-2034)

## Issues and Limitations

Side effect is that React users will require a polyfill, which is autoloaded behind the scenes. This also prevents us from using the custom elements build at the moment.

## Types of changes

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change

## Checklist

-   [ ] This PR adds or removes a Storybook story.
-   [ ] I have added tests to cover my changes.
